### PR TITLE
fix: wrap location sidebar content in aside

### DIFF
--- a/components/LocationSideBar.js
+++ b/components/LocationSideBar.js
@@ -44,8 +44,9 @@ export default function LocationSideBar({ open, location, onClose, isAdmin, merc
   };
 
   return (
-    className="fixed top-0 right-0 h-full w-[90vw] sm:w-[400px] max-w-full bg-amber-100 bg-opacity-95 shadow-2xl z-50 border-l-4 border-yellow-700 flex flex-col p-6 font-serif transition-transform"
-      style={{ transform: open ? "translateX(0)" : "translateX(100%)", transition: "transform 0.3s ease-in-out" }}
+    <aside
+      className="fixed top-0 right-0 h-full w-[90vw] sm:w-[400px] max-w-full bg-amber-100 bg-opacity-95 shadow-2xl z-50 border-l-4 border-yellow-700 flex flex-col p-6 font-serif transition-transform"
+      style={{ transform: open ? 'translateX(0)' : 'translateX(100%)', transition: 'transform 0.3s ease-in-out' }}
     >
       {/* Close Button */}
       <button


### PR DESCRIPTION
## Summary
- wrap `LocationSideBar` content in `<aside>` tag and include style to slide open and closed

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688ea5f711b88322a23a869204262669