### PR TITLE
Add player self-registration and profile settings

### DIFF
--- a/components/AppNavbar.js
+++ b/components/AppNavbar.js
@@ -10,13 +10,39 @@ const supabase = createClient(
 
 export default function AppNavbar() {
   const [user, setUser] = useState(null);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => setUser(data.session?.user || null));
-    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) =>
-      setUser(s?.user || null)
-    );
-    return () => sub.subscription.unsubscribe();
+    let active = true;
+
+    async function applySession(session) {
+      const nextUser = session?.user || null;
+      if (!active) return;
+      setUser(nextUser);
+
+      if (!nextUser) {
+        setIsAdmin(false);
+        return;
+      }
+
+      try {
+        const { data, error } = await supabase.rpc("is_admin");
+        if (error) throw error;
+        if (active) setIsAdmin(Boolean(data));
+      } catch {
+        if (active) setIsAdmin(false);
+      }
+    }
+
+    supabase.auth.getSession().then(({ data }) => applySession(data?.session));
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
+      applySession(session);
+    });
+
+    return () => {
+      active = false;
+      subscription.subscription.unsubscribe();
+    };
   }, []);
 
   async function signOut() {
@@ -34,6 +60,9 @@ export default function AppNavbar() {
           type="button"
           data-bs-toggle="collapse"
           data-bs-target="#mainNav"
+          aria-controls="mainNav"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
         >
           <span className="navbar-toggler-icon"></span>
         </button>
@@ -44,18 +73,28 @@ export default function AppNavbar() {
             <li className="nav-item"><Link className="nav-link" href="/npcs">NPCs</Link></li>
             <li className="nav-item"><Link className="nav-link" href="/items">Crafting</Link></li>
             <li className="nav-item"><Link className="nav-link" href="/inventory">Inventory</Link></li>
-            <li className="nav-item"><Link className="nav-link" href="/admin">Admin</Link></li>
+            {user && (
+              <li className="nav-item"><Link className="nav-link" href="/profile">Profile</Link></li>
+            )}
+            {isAdmin && (
+              <li className="nav-item"><Link className="nav-link" href="/admin">Admin</Link></li>
+            )}
           </ul>
 
-          <div className="d-flex">
+          <div className="d-flex gap-2">
             {user ? (
               <button className="btn btn-outline-secondary btn-sm" onClick={signOut}>
                 Logout
               </button>
             ) : (
-              <Link className="btn btn-primary btn-sm" href="/login">
-                Login
-              </Link>
+              <>
+                <Link className="btn btn-outline-primary btn-sm" href="/signup">
+                  Create account
+                </Link>
+                <Link className="btn btn-primary btn-sm" href="/login">
+                  Login
+                </Link>
+              </>
             )}
           </div>
         </div>

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { createClient } from "@supabase/supabase-js";
 
@@ -7,6 +8,12 @@ const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
+function safeLocalPath(value) {
+  if (typeof value !== "string") return null;
+  if (!value.startsWith("/") || value.startsWith("//")) return null;
+  return value;
+}
+
 export default function LoginPage() {
   const router = useRouter();
   const [email, setEmail] = useState("");
@@ -14,17 +21,46 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  async function onSubmit(e) {
-    e.preventDefault();
+  async function onSubmit(event) {
+    event.preventDefault();
     setError("");
     setLoading(true);
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
-    setLoading(false);
-    if (error) {
-      setError(error.message || "Login failed.");
-    } else {
-      router.push("/admin");
+
+    const { data, error: loginError } = await supabase.auth.signInWithPassword({
+      email: email.trim().toLowerCase(),
+      password,
+    });
+
+    if (loginError) {
+      setLoading(false);
+      setError(loginError.message || "Login failed.");
+      return;
     }
+
+    const requestedPath = safeLocalPath(router.query.next);
+    if (requestedPath) {
+      router.replace(requestedPath);
+      return;
+    }
+
+    let isAdmin = false;
+    try {
+      const { data: adminResult, error: adminError } = await supabase.rpc("is_admin");
+      if (adminError) throw adminError;
+      isAdmin = Boolean(adminResult);
+    } catch {
+      const userId = data?.user?.id || data?.session?.user?.id;
+      if (userId) {
+        const { data: profile } = await supabase
+          .from("user_profiles")
+          .select("role")
+          .eq("id", userId)
+          .maybeSingle();
+        isAdmin = (profile?.role || "player") !== "player";
+      }
+    }
+
+    router.replace(isAdmin ? "/admin" : "/profile");
   }
 
   return (
@@ -32,28 +68,37 @@ export default function LoginPage() {
       <div className="row justify-content-center">
         <div className="col-12 col-sm-10 col-md-6 col-lg-5">
           <div className="card shadow-sm">
-            <div className="card-body">
+            <div className="card-body p-4">
               <h1 className="h4 mb-3">Sign in</h1>
+
+              {router.query.confirmed === "1" && (
+                <div className="alert alert-success">
+                  Email confirmed. Sign in with the password you created.
+                </div>
+              )}
+
               <form onSubmit={onSubmit} className="d-grid gap-3">
                 <div>
-                  <label className="form-label">Email</label>
+                  <label className="form-label" htmlFor="loginEmail">Email</label>
                   <input
+                    id="loginEmail"
                     type="email"
                     className="form-control"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    onChange={(event) => setEmail(event.target.value)}
                     autoComplete="email"
                     required
                   />
                 </div>
 
                 <div>
-                  <label className="form-label">Password</label>
+                  <label className="form-label" htmlFor="loginPassword">Password</label>
                   <input
+                    id="loginPassword"
                     type="password"
                     className="form-control"
                     value={password}
-                    onChange={(e) => setPassword(e.target.value)}
+                    onChange={(event) => setPassword(event.target.value)}
                     autoComplete="current-password"
                     required
                   />
@@ -65,6 +110,11 @@ export default function LoginPage() {
 
                 {error && <div className="alert alert-danger m-0">{error}</div>}
               </form>
+
+              <hr className="my-4" />
+              <p className="mb-0 text-center">
+                New player? <Link href="/signup">Create an account</Link>
+              </p>
             </div>
           </div>
         </div>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,0 +1,316 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+const MIN_PASSWORD_LENGTH = 8;
+
+function fallbackPlayerName(user) {
+  const metadataName = String(user?.user_metadata?.character_name || "").trim();
+  if (metadataName) return metadataName.slice(0, 80);
+  const emailName = String(user?.email || "").split("@")[0].trim();
+  return (emailName || "New Player").slice(0, 80);
+}
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const [user, setUser] = useState(null);
+  const [playerId, setPlayerId] = useState(null);
+  const [name, setName] = useState("");
+  const [role, setRole] = useState("player");
+  const [loading, setLoading] = useState(true);
+  const [profileSaving, setProfileSaving] = useState(false);
+  const [profileMessage, setProfileMessage] = useState("");
+  const [profileError, setProfileError] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [passwordSaving, setPasswordSaving] = useState(false);
+  const [passwordMessage, setPasswordMessage] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadProfile() {
+      const { data: sessionData } = await supabase.auth.getSession();
+      const session = sessionData?.session;
+
+      if (!session) {
+        router.replace("/login?next=/profile");
+        return;
+      }
+
+      const currentUser = session.user;
+      if (!active) return;
+      setUser(currentUser);
+
+      const [{ data: player, error: playerError }, { data: profile }] = await Promise.all([
+        supabase
+          .from("players")
+          .select("id,user_id,name")
+          .eq("user_id", currentUser.id)
+          .maybeSingle(),
+        supabase
+          .from("user_profiles")
+          .select("role")
+          .eq("id", currentUser.id)
+          .maybeSingle(),
+      ]);
+
+      if (!active) return;
+
+      if (playerError) {
+        setProfileError(playerError.message || "Could not load the player profile.");
+      }
+
+      if (player) {
+        setPlayerId(player.id);
+        setName(player.name || fallbackPlayerName(currentUser));
+      } else {
+        const initialName = fallbackPlayerName(currentUser);
+        const { data: createdPlayer, error: createError } = await supabase
+          .from("players")
+          .insert({ user_id: currentUser.id, name: initialName })
+          .select("id,user_id,name")
+          .single();
+
+        if (!active) return;
+
+        if (createError) {
+          setName(initialName);
+          setProfileError(createError.message || "Could not create the player profile.");
+        } else {
+          setPlayerId(createdPlayer.id);
+          setName(createdPlayer.name);
+        }
+      }
+
+      setRole(profile?.role || "player");
+      setLoading(false);
+    }
+
+    loadProfile();
+
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  async function saveProfile(event) {
+    event.preventDefault();
+    setProfileError("");
+    setProfileMessage("");
+
+    const cleanName = name.trim();
+    if (cleanName.length < 2) {
+      setProfileError("Enter a player or character name with at least 2 characters.");
+      return;
+    }
+    if (cleanName.length > 80) {
+      setProfileError("Player names must be 80 characters or fewer.");
+      return;
+    }
+    if (!user) {
+      setProfileError("Your session has expired. Sign in again.");
+      return;
+    }
+
+    setProfileSaving(true);
+
+    let query = supabase
+      .from("players")
+      .update({ name: cleanName, updated_at: new Date().toISOString() })
+      .eq("user_id", user.id)
+      .select("id,name")
+      .single();
+
+    if (!playerId) {
+      query = supabase
+        .from("players")
+        .upsert({ user_id: user.id, name: cleanName }, { onConflict: "user_id" })
+        .select("id,name")
+        .single();
+    }
+
+    const { data: savedPlayer, error: saveError } = await query;
+
+    if (saveError) {
+      setProfileSaving(false);
+      setProfileError(saveError.message || "Could not save the player profile.");
+      return;
+    }
+
+    const { error: metadataError } = await supabase.auth.updateUser({
+      data: { character_name: cleanName },
+    });
+
+    setPlayerId(savedPlayer.id);
+    setName(savedPlayer.name);
+    setProfileSaving(false);
+    setProfileMessage(
+      metadataError
+        ? "Profile saved. The account display metadata will update after your next sign-in."
+        : "Profile saved."
+    );
+  }
+
+  async function changePassword(event) {
+    event.preventDefault();
+    setPasswordError("");
+    setPasswordMessage("");
+
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      setPasswordError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setPasswordError("The passwords do not match.");
+      return;
+    }
+
+    setPasswordSaving(true);
+    const { error } = await supabase.auth.updateUser({ password: newPassword });
+    setPasswordSaving(false);
+
+    if (error) {
+      setPasswordError(error.message || "Could not update the password.");
+      return;
+    }
+
+    setNewPassword("");
+    setConfirmPassword("");
+    setPasswordMessage("Password updated.");
+  }
+
+  if (loading) {
+    return <div className="container py-5">Loading profile…</div>;
+  }
+
+  return (
+    <div className="container py-5">
+      <div className="row justify-content-center g-4">
+        <div className="col-12 col-lg-7">
+          {router.query.welcome === "1" && (
+            <div className="alert alert-success">
+              Your player account is ready. Review the name below before continuing.
+            </div>
+          )}
+
+          <div className="card shadow-sm mb-4">
+            <div className="card-body p-4">
+              <div className="d-flex justify-content-between align-items-start gap-3 mb-4">
+                <div>
+                  <h1 className="h4 mb-1">Player profile</h1>
+                  <p className="text-body-secondary mb-0">
+                    This name appears in player lists, inventory tools, and campaign requests.
+                  </p>
+                </div>
+                <span className="badge text-bg-secondary text-capitalize">{role}</span>
+              </div>
+
+              <form onSubmit={saveProfile} className="d-grid gap-3">
+                <div>
+                  <label className="form-label" htmlFor="profileEmail">Email</label>
+                  <input
+                    id="profileEmail"
+                    className="form-control"
+                    value={user?.email || ""}
+                    readOnly
+                    disabled
+                  />
+                </div>
+
+                <div>
+                  <label className="form-label" htmlFor="profileName">
+                    Player or character name
+                  </label>
+                  <input
+                    id="profileName"
+                    className="form-control"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    maxLength={80}
+                    required
+                  />
+                </div>
+
+                <button className="btn btn-primary" type="submit" disabled={profileSaving}>
+                  {profileSaving ? "Saving…" : "Save profile"}
+                </button>
+
+                {profileMessage && <div className="alert alert-success m-0">{profileMessage}</div>}
+                {profileError && <div className="alert alert-danger m-0">{profileError}</div>}
+              </form>
+            </div>
+          </div>
+
+          <div className="card shadow-sm">
+            <div className="card-body p-4">
+              <h2 className="h5 mb-1">Change password</h2>
+              <p className="text-body-secondary mb-4">
+                Choose a new password for this account.
+              </p>
+
+              <form onSubmit={changePassword} className="d-grid gap-3">
+                <div>
+                  <label className="form-label" htmlFor="newPassword">New password</label>
+                  <input
+                    id="newPassword"
+                    type={showPassword ? "text" : "password"}
+                    className="form-control"
+                    value={newPassword}
+                    onChange={(event) => setNewPassword(event.target.value)}
+                    autoComplete="new-password"
+                    minLength={MIN_PASSWORD_LENGTH}
+                    required
+                  />
+                </div>
+
+                <div>
+                  <label className="form-label" htmlFor="confirmNewPassword">
+                    Confirm new password
+                  </label>
+                  <input
+                    id="confirmNewPassword"
+                    type={showPassword ? "text" : "password"}
+                    className="form-control"
+                    value={confirmPassword}
+                    onChange={(event) => setConfirmPassword(event.target.value)}
+                    autoComplete="new-password"
+                    minLength={MIN_PASSWORD_LENGTH}
+                    required
+                  />
+                </div>
+
+                <div className="form-check">
+                  <input
+                    id="showProfilePassword"
+                    type="checkbox"
+                    className="form-check-input"
+                    checked={showPassword}
+                    onChange={(event) => setShowPassword(event.target.checked)}
+                  />
+                  <label className="form-check-label" htmlFor="showProfilePassword">
+                    Show password
+                  </label>
+                </div>
+
+                <button className="btn btn-outline-primary" type="submit" disabled={passwordSaving}>
+                  {passwordSaving ? "Updating…" : "Update password"}
+                </button>
+
+                {passwordMessage && <div className="alert alert-success m-0">{passwordMessage}</div>}
+                {passwordError && <div className="alert alert-danger m-0">{passwordError}</div>}
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,0 +1,216 @@
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+const MIN_PASSWORD_LENGTH = 8;
+
+export default function SignupPage() {
+  const router = useRouter();
+  const [characterName, setCharacterName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [submittedEmail, setSubmittedEmail] = useState("");
+
+  async function onSubmit(event) {
+    event.preventDefault();
+    setError("");
+
+    const cleanName = characterName.trim();
+    const cleanEmail = email.trim().toLowerCase();
+
+    if (cleanName.length < 2) {
+      setError("Enter the player or character name you want shown on the site.");
+      return;
+    }
+    if (cleanName.length > 80) {
+      setError("Player names must be 80 characters or fewer.");
+      return;
+    }
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("The passwords do not match.");
+      return;
+    }
+
+    setLoading(true);
+
+    const emailRedirectTo =
+      typeof window !== "undefined"
+        ? `${window.location.origin}/login?confirmed=1`
+        : undefined;
+
+    const { data, error: signupError } = await supabase.auth.signUp({
+      email: cleanEmail,
+      password,
+      options: {
+        data: {
+          character_name: cleanName,
+        },
+        emailRedirectTo,
+      },
+    });
+
+    setLoading(false);
+
+    if (signupError) {
+      setError(signupError.message || "Account creation failed.");
+      return;
+    }
+
+    if (data?.session) {
+      router.replace("/profile?welcome=1");
+      return;
+    }
+
+    setSubmittedEmail(cleanEmail);
+    setPassword("");
+    setConfirmPassword("");
+  }
+
+  if (submittedEmail) {
+    return (
+      <div className="container py-5">
+        <div className="row justify-content-center">
+          <div className="col-12 col-sm-10 col-md-7 col-lg-5">
+            <div className="card shadow-sm">
+              <div className="card-body p-4">
+                <h1 className="h4 mb-3">Check your email</h1>
+                <p className="mb-3">
+                  A confirmation link was sent to <strong>{submittedEmail}</strong>.
+                  Open that link to activate your player account, then sign in with
+                  the password you just created.
+                </p>
+                <div className="d-grid gap-2">
+                  <Link className="btn btn-primary" href="/login">
+                    Return to sign in
+                  </Link>
+                  <button
+                    type="button"
+                    className="btn btn-outline-secondary"
+                    onClick={() => setSubmittedEmail("")}
+                  >
+                    Use a different email
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container py-5">
+      <div className="row justify-content-center">
+        <div className="col-12 col-sm-10 col-md-7 col-lg-5">
+          <div className="card shadow-sm">
+            <div className="card-body p-4">
+              <h1 className="h4 mb-1">Create a player account</h1>
+              <p className="text-body-secondary mb-4">
+                Choose the name shown to the campaign, then set your email and password.
+              </p>
+
+              <form onSubmit={onSubmit} className="d-grid gap-3">
+                <div>
+                  <label className="form-label" htmlFor="characterName">
+                    Player or character name
+                  </label>
+                  <input
+                    id="characterName"
+                    type="text"
+                    className="form-control"
+                    value={characterName}
+                    onChange={(event) => setCharacterName(event.target.value)}
+                    autoComplete="nickname"
+                    maxLength={80}
+                    required
+                  />
+                </div>
+
+                <div>
+                  <label className="form-label" htmlFor="signupEmail">Email</label>
+                  <input
+                    id="signupEmail"
+                    type="email"
+                    className="form-control"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    autoComplete="email"
+                    required
+                  />
+                </div>
+
+                <div>
+                  <label className="form-label" htmlFor="signupPassword">Password</label>
+                  <input
+                    id="signupPassword"
+                    type={showPassword ? "text" : "password"}
+                    className="form-control"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                    autoComplete="new-password"
+                    minLength={MIN_PASSWORD_LENGTH}
+                    required
+                  />
+                  <div className="form-text">At least {MIN_PASSWORD_LENGTH} characters.</div>
+                </div>
+
+                <div>
+                  <label className="form-label" htmlFor="confirmPassword">Confirm password</label>
+                  <input
+                    id="confirmPassword"
+                    type={showPassword ? "text" : "password"}
+                    className="form-control"
+                    value={confirmPassword}
+                    onChange={(event) => setConfirmPassword(event.target.value)}
+                    autoComplete="new-password"
+                    minLength={MIN_PASSWORD_LENGTH}
+                    required
+                  />
+                </div>
+
+                <div className="form-check">
+                  <input
+                    id="showPassword"
+                    type="checkbox"
+                    className="form-check-input"
+                    checked={showPassword}
+                    onChange={(event) => setShowPassword(event.target.checked)}
+                  />
+                  <label className="form-check-label" htmlFor="showPassword">
+                    Show password
+                  </label>
+                </div>
+
+                <button type="submit" className="btn btn-primary" disabled={loading}>
+                  {loading ? "Creating account…" : "Create player account"}
+                </button>
+
+                {error && <div className="alert alert-danger m-0">{error}</div>}
+              </form>
+
+              <hr className="my-4" />
+              <p className="mb-0 text-center">
+                Already have an account? <Link href="/login">Sign in</Link>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/sql/20260612_93_player_signup_profiles.sql
+++ b/sql/20260612_93_player_signup_profiles.sql
@@ -1,0 +1,125 @@
+-- DNDNext player self-registration and profile provisioning.
+--
+-- New email/password accounts are always provisioned as players. User-supplied
+-- metadata is used only for the player-facing name and can never assign roles.
+
+BEGIN;
+
+CREATE UNIQUE INDEX IF NOT EXISTS players_user_id_uidx
+ON public.players (user_id);
+
+CREATE OR REPLACE FUNCTION public.sync_user_profile()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public, auth
+AS $function$
+DECLARE
+  profile_name text;
+BEGIN
+  profile_name := left(
+    COALESCE(
+      NULLIF(btrim(NEW.raw_user_meta_data->>'character_name'), ''),
+      NULLIF(btrim(NEW.raw_user_meta_data->>'display_name'), ''),
+      NULLIF(btrim(split_part(COALESCE(NEW.email, ''), '@', 1)), ''),
+      'New Player'
+    ),
+    80
+  );
+
+  -- Never trust user-editable metadata for authorization. New accounts always
+  -- start as players; only an existing administrator may elevate a role later.
+  INSERT INTO public.user_profiles (id, role)
+  VALUES (NEW.id, 'player')
+  ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO public.players (user_id, name)
+  VALUES (NEW.id, profile_name)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.sync_user_profile() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.sync_user_profile() TO service_role;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_user_profile();
+
+-- Backfill the player-facing row for existing accounts without changing any
+-- existing role or player record.
+INSERT INTO public.user_profiles (id, role)
+SELECT users.id, 'player'
+FROM auth.users AS users
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.players (user_id, name)
+SELECT
+  users.id,
+  left(
+    COALESCE(
+      NULLIF(btrim(users.raw_user_meta_data->>'character_name'), ''),
+      NULLIF(btrim(users.raw_user_meta_data->>'display_name'), ''),
+      NULLIF(btrim(split_part(COALESCE(users.email, ''), '@', 1)), ''),
+      'New Player'
+    ),
+    80
+  )
+FROM auth.users AS users
+ON CONFLICT (user_id) DO NOTHING;
+
+-- Replace the duplicated legacy player policies with one explicit policy set.
+DO $policies$
+DECLARE
+  policy_row record;
+BEGIN
+  FOR policy_row IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'players'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.players', policy_row.policyname);
+  END LOOP;
+END;
+$policies$;
+
+ALTER TABLE public.players ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.players FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.players TO authenticated;
+GRANT ALL ON TABLE public.players TO service_role;
+
+CREATE POLICY players_select_self
+ON public.players
+FOR SELECT
+TO authenticated
+USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY players_insert_self
+ON public.players
+FOR INSERT
+TO authenticated
+WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY players_update_self
+ON public.players
+FOR UPDATE
+TO authenticated
+USING (user_id = (SELECT auth.uid()))
+WITH CHECK (user_id = (SELECT auth.uid()));
+
+CREATE POLICY players_admin_all
+ON public.players
+FOR ALL
+TO authenticated
+USING ((SELECT private.current_user_is_admin()))
+WITH CHECK ((SELECT private.current_user_is_admin()));
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/sql/20260612_99_player_signup_verify.sql
+++ b/sql/20260612_99_player_signup_verify.sql
@@ -1,0 +1,104 @@
+-- DNDNext player signup/profile verification.
+-- Read-only. Raises an exception when provisioning or access controls are missing.
+
+DO $verify$
+DECLARE
+  auth_user_count integer;
+  player_profile_count integer;
+  role_profile_count integer;
+  duplicate_user_count integer;
+  missing_policies text[];
+BEGIN
+  SELECT count(*) INTO auth_user_count FROM auth.users;
+  SELECT count(DISTINCT user_id) INTO player_profile_count
+  FROM public.players
+  WHERE user_id IS NOT NULL;
+  SELECT count(*) INTO role_profile_count
+  FROM public.user_profiles
+  WHERE id IN (SELECT id FROM auth.users);
+
+  IF player_profile_count <> auth_user_count THEN
+    RAISE EXCEPTION 'Signup verification failed: % auth users but % player rows',
+      auth_user_count, player_profile_count;
+  END IF;
+
+  IF role_profile_count <> auth_user_count THEN
+    RAISE EXCEPTION 'Signup verification failed: % auth users but % role rows',
+      auth_user_count, role_profile_count;
+  END IF;
+
+  SELECT count(*) INTO duplicate_user_count
+  FROM (
+    SELECT user_id
+    FROM public.players
+    WHERE user_id IS NOT NULL
+    GROUP BY user_id
+    HAVING count(*) > 1
+  ) duplicates;
+
+  IF duplicate_user_count <> 0 THEN
+    RAISE EXCEPTION 'Signup verification failed: duplicate player rows exist for % users',
+      duplicate_user_count;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger trigger_row
+    JOIN pg_class table_row ON table_row.oid = trigger_row.tgrelid
+    JOIN pg_namespace schema_row ON schema_row.oid = table_row.relnamespace
+    WHERE schema_row.nspname = 'auth'
+      AND table_row.relname = 'users'
+      AND trigger_row.tgname = 'on_auth_user_created'
+      AND NOT trigger_row.tgisinternal
+      AND trigger_row.tgenabled <> 'D'
+  ) THEN
+    RAISE EXCEPTION 'Signup verification failed: auth user provisioning trigger is missing';
+  END IF;
+
+  IF position(
+    'values (new.id, ''player'')'
+    IN lower(pg_get_functiondef('public.sync_user_profile()'::regprocedure))
+  ) = 0 THEN
+    RAISE EXCEPTION 'Signup verification failed: new profiles are not forced to player';
+  END IF;
+
+  IF has_table_privilege('anon', 'public.players', 'SELECT')
+     OR has_table_privilege('anon', 'public.players', 'INSERT')
+     OR has_table_privilege('anon', 'public.players', 'UPDATE')
+     OR has_table_privilege('anon', 'public.players', 'DELETE') THEN
+    RAISE EXCEPTION 'Signup verification failed: anon retains direct players-table privileges';
+  END IF;
+
+  SELECT array_agg(required.policy_name ORDER BY required.policy_name)
+  INTO missing_policies
+  FROM (
+    VALUES
+      ('players_select_self'),
+      ('players_insert_self'),
+      ('players_update_self'),
+      ('players_admin_all')
+  ) required(policy_name)
+  LEFT JOIN pg_policies policy_row
+    ON policy_row.schemaname = 'public'
+   AND policy_row.tablename = 'players'
+   AND policy_row.policyname = required.policy_name
+  WHERE policy_row.policyname IS NULL;
+
+  IF missing_policies IS NOT NULL THEN
+    RAISE EXCEPTION 'Signup verification failed: policies missing %', missing_policies;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM public.user_profiles WHERE role = 'admin') THEN
+    RAISE EXCEPTION 'Signup verification failed: no administrator profile remains';
+  END IF;
+END;
+$verify$;
+
+SELECT jsonb_build_object(
+  'status', 'ok',
+  'auth_users', (SELECT count(*) FROM auth.users),
+  'player_rows', (SELECT count(*) FROM public.players WHERE user_id IS NOT NULL),
+  'role_rows', (SELECT count(*) FROM public.user_profiles),
+  'admin_rows', (SELECT count(*) FROM public.user_profiles WHERE role = 'admin'),
+  'trigger_function', pg_get_functiondef('public.sync_user_profile()'::regprocedure)
+) AS player_signup_verification;


### PR DESCRIPTION
## Scope
Adds player email/password sign-up and self-service profile settings. No map, crafting, alchemy, recipe, or foraging behavior changes.

## User experience
- New `/signup` page collects player/character name, email, password, and password confirmation.
- Email-confirmation flow returns users to `/login?confirmed=1`.
- New `/profile` page lets signed-in players update their campaign name and change their password.
- Login routes admins to `/admin` and players to `/profile`.
- Navbar shows Create Account while signed out, Profile while signed in, and Admin only for elevated users.

## Database safety
- New auth accounts are always assigned `player`; user-editable metadata can no longer request an admin role.
- Auth trigger provisions both `user_profiles` and `players` rows transactionally.
- Adds one-player-row-per-auth-user uniqueness.
- Backfills missing player rows for existing auth accounts without changing existing roles.
- Replaces duplicated players policies with explicit self-service and admin policies.

## Live deployment
Applied to Supabase project `ucggczovhmauhshvhusx`:
- `20260612154141 player_signup_profiles`

## Verification
- Migration passed a full transactional rollback test before deployment.
- Read-only verifier passed after deployment.
- All 3 existing auth users now have exactly one `players` row and one role row.
- Existing administrator role remained unchanged.
- Synthetic auth-user trigger test with forged `role: admin` metadata still created a `player` role and the expected display name; test was rolled back.
- Player JWT sees exactly its own player row, can update its own name, and cannot update another user.
- Administrator JWT sees all player rows.
- Anonymous direct access to `players` is removed.
- Latest Vercel preview build passed.

No world-map files or behavior were touched.