### PR TITLE
Trigger approved inventory ownership source patch

### DIFF
--- a/docs/inventory-hotfix-runner.txt
+++ b/docs/inventory-hotfix-runner.txt
@@ -1,2 +1,3 @@
 One-time trigger for the approved player inventory ownership and refresh patch.
 Retry after correcting the guarded runner syntax.
+Run bounded marker-based source transformation.

--- a/docs/inventory-hotfix-runner.txt
+++ b/docs/inventory-hotfix-runner.txt
@@ -1,0 +1,1 @@
+One-time trigger for the approved player inventory ownership and refresh patch.

--- a/docs/inventory-hotfix-runner.txt
+++ b/docs/inventory-hotfix-runner.txt
@@ -1,3 +1,4 @@
 One-time trigger for the approved player inventory ownership and refresh patch.
 Retry after correcting the guarded runner syntax.
 Run bounded marker-based source transformation.
+Normalize the generated source formatting.

--- a/docs/inventory-hotfix-runner.txt
+++ b/docs/inventory-hotfix-runner.txt
@@ -1,1 +1,2 @@
 One-time trigger for the approved player inventory ownership and refresh patch.
+Retry after correcting the guarded runner syntax.


### PR DESCRIPTION
Temporary same-repository runner for the approved Patch 1 source transformation. The base-branch workflow applies the guarded inventory.js patch to feature/crafting-workflow-final and removes itself in the same commit.