### PR TITLE
Fix merchant alchemy duration qualifiers and brewed ingredients

### DIFF
--- a/scripts/patch_itemcard_alchemy_details.mjs
+++ b/scripts/patch_itemcard_alchemy_details.mjs
@@ -4,53 +4,78 @@ import path from "node:path";
 const filePath = path.join(process.cwd(), "components", "ItemCard.js");
 let source = fs.readFileSync(filePath, "utf8");
 
-if (!source.includes("saveLabel: saveDc ?")) {
-  const fn = [
-    'function potionDetailsForItem(item = {}, type = "", ruleText = "", entriesText = "") {',
-    '  if (!isPotionLikeItem(item, type)) return null;',
-    '  const name = item.item_name || item.name || "";',
-    '  const known = POTION_DETAIL_OVERRIDES[name] || {};',
-    '  const alchemy = item.alchemy && typeof item.alchemy === "object" ? item.alchemy : {};',
-    '  const result = item.alchemy_result && typeof item.alchemy_result === "object" ? item.alchemy_result : {};',
-    '  const craft = item.merchant_craft && typeof item.merchant_craft === "object" ? item.merchant_craft : {};',
-    '  const savePreview = result.saveDcPreview && typeof result.saveDcPreview === "object" ? result.saveDcPreview : {};',
-    '  const sourceText = [ruleText, entriesText, item.effect_text, item.effect, alchemy.effect, result.effect, item.rulesText].filter(Boolean).join("\\n");',
-    '  const duration = craft.duration || result.duration || alchemy.duration || item.duration || item.duration_text || known.duration || extractDuration(sourceText) || "See item text";',
-    '  const use = craft.use || result.use || alchemy.use || item.use || item.use_text || item.activation || item.application || known.use || (/oil/i.test(name) ? "Bonus Action to use or apply" : "Action to drink/use");',
-    '  const effect = item.effect_detail || result.effect || alchemy.effect || item.effect_text || item.effect || known.effect || sourceText || "See item text.";',
-    '  const saveDc = item.save_dc || craft.save_dc || alchemy.saveDc || savePreview.dc || null;',
-    '  const saveAbility = item.save_ability || craft.save_ability || alchemy.saveAbility || savePreview.saveAbility || null;',
-    '  const doses = item.charges ?? craft.doses ?? alchemy.doses ?? result.doses ?? null;',
-    '  return {',
-    '    use, duration, effect, saveDc, saveAbility, doses,',
-    '    saveLabel: saveDc ? (saveAbility ? String(saveAbility) + " DC " + String(saveDc) : "DC " + String(saveDc)) : null,',
-    '  };',
-    '}'
-  ].join('\n');
+const fn = [
+  'function potionDetailsForItem(item = {}, type = "", ruleText = "", entriesText = "") {',
+  '  if (!isPotionLikeItem(item, type)) return null;',
+  '  const name = item.item_name || item.name || "";',
+  '  const known = POTION_DETAIL_OVERRIDES[name] || {};',
+  '  const alchemy = item.alchemy && typeof item.alchemy === "object" ? item.alchemy : {};',
+  '  const result = item.alchemy_result && typeof item.alchemy_result === "object" ? item.alchemy_result : {};',
+  '  const craft = item.merchant_craft && typeof item.merchant_craft === "object" ? item.merchant_craft : {};',
+  '  const savePreview = result.saveDcPreview && typeof result.saveDcPreview === "object" ? result.saveDcPreview : {};',
+  '  const sourceText = [ruleText, entriesText, item.effect_text, item.effect, alchemy.effect, result.effect, item.rulesText].filter(Boolean).join("\\n");',
+  '  const duration = craft.duration || result.duration || alchemy.duration || item.duration || item.duration_text || known.duration || extractDuration(sourceText) || "See item text";',
+  '  const use = craft.use || result.use || alchemy.use || item.use || item.use_text || item.activation || item.application || known.use || (/oil/i.test(name) ? "Bonus Action to use or apply" : "Action to drink/use");',
+  '  const effect = item.effect_detail || result.effect || alchemy.effect || item.effect_text || item.effect || known.effect || sourceText || "See item text.";',
+  '  const saveDc = item.save_dc || craft.save_dc || alchemy.saveDc || savePreview.dc || null;',
+  '  const saveAbility = item.save_ability || craft.save_ability || alchemy.saveAbility || savePreview.saveAbility || null;',
+  '  const doses = item.charges ?? craft.doses ?? alchemy.doses ?? result.doses ?? null;',
+  '  const selectedIngredients = item.selected_ingredients || alchemy.selectedIngredients || result.selectedIngredients || craft.ingredients || [];',
+  '  const ingredientLine = item.ingredient_line || alchemy.ingredientLine || result.ingredientLine || craft.ingredient_line || (Array.isArray(selectedIngredients) ? selectedIngredients.map((ingredient) => {',
+  '    const ingredientName = ingredient?.name || ingredient?.item_name;',
+  '    if (!ingredientName) return null;',
+  '    const detail = [ingredient?.family_label || ingredient?.family, ingredient?.rarity].filter(Boolean).join(", ");',
+  '    return detail ? ingredientName + " (" + detail + ")" : ingredientName;',
+  '  }).filter(Boolean).join("; ") : "");',
+  '  return {',
+  '    use, duration, effect, saveDc, saveAbility, doses, ingredientLine,',
+  '    saveLabel: saveDc ? (saveAbility ? String(saveAbility) + " DC " + String(saveDc) : "DC " + String(saveDc)) : null,',
+  '  };',
+  '}'
+].join('\n');
 
+const originalRows = [
+  '            <div className="row g-2">',
+  '              <div className="col-12 col-md-6"><strong>Use:</strong> {potionDetails.use}</div>',
+  '              <div className="col-12 col-md-6"><strong>Duration:</strong> {potionDetails.duration}</div>',
+  '              <div className="col-12"><strong>Effect:</strong> {potionDetails.effect}</div>',
+  '            </div>'
+].join('\n');
+
+const previouslyPatchedRows = [
+  '            <div className="row g-2">',
+  '              <div className="col-12 col-md-6"><strong>Use:</strong> {potionDetails.use}</div>',
+  '              <div className="col-12 col-md-6"><strong>Duration:</strong> {potionDetails.duration}</div>',
+  '              {potionDetails.saveLabel ? <div className="col-12 col-md-6"><strong>Save:</strong> {potionDetails.saveLabel}</div> : null}',
+  '              {potionDetails.doses != null ? <div className="col-12 col-md-6"><strong>Doses:</strong> {potionDetails.doses}</div> : null}',
+  '              <div className="col-12"><strong>Effect:</strong> {potionDetails.effect}</div>',
+  '            </div>'
+].join('\n');
+
+const newRows = [
+  '            <div className="row g-2">',
+  '              <div className="col-12 col-md-6"><strong>Use:</strong> {potionDetails.use}</div>',
+  '              <div className="col-12 col-md-6"><strong>Duration:</strong> {potionDetails.duration}</div>',
+  '              {potionDetails.saveLabel ? <div className="col-12 col-md-6"><strong>Save:</strong> {potionDetails.saveLabel}</div> : null}',
+  '              {potionDetails.doses != null ? <div className="col-12 col-md-6"><strong>Doses:</strong> {potionDetails.doses}</div> : null}',
+  '              {potionDetails.ingredientLine ? <div className="col-12"><strong>Brewed With:</strong> {potionDetails.ingredientLine}</div> : null}',
+  '              <div className="col-12"><strong>Effect:</strong> {potionDetails.effect}</div>',
+  '            </div>'
+].join('\n');
+
+if (!source.includes("potionDetails.ingredientLine")) {
   const fnRx = /function potionDetailsForItem\(item = \{\}, type = "", ruleText = "", entriesText = ""\) \{[\s\S]*?\n\}/;
   if (!fnRx.test(source)) throw new Error("potionDetailsForItem function not found");
   source = source.replace(fnRx, fn);
 
-  const oldRows = [
-    '            <div className="row g-2">',
-    '              <div className="col-12 col-md-6"><strong>Use:</strong> {potionDetails.use}</div>',
-    '              <div className="col-12 col-md-6"><strong>Duration:</strong> {potionDetails.duration}</div>',
-    '              <div className="col-12"><strong>Effect:</strong> {potionDetails.effect}</div>',
-    '            </div>'
-  ].join('\n');
-  const newRows = [
-    '            <div className="row g-2">',
-    '              <div className="col-12 col-md-6"><strong>Use:</strong> {potionDetails.use}</div>',
-    '              <div className="col-12 col-md-6"><strong>Duration:</strong> {potionDetails.duration}</div>',
-    '              {potionDetails.saveLabel ? <div className="col-12 col-md-6"><strong>Save:</strong> {potionDetails.saveLabel}</div> : null}',
-    '              {potionDetails.doses != null ? <div className="col-12 col-md-6"><strong>Doses:</strong> {potionDetails.doses}</div> : null}',
-    '              <div className="col-12"><strong>Effect:</strong> {potionDetails.effect}</div>',
-    '            </div>'
-  ].join('\n');
-  const count = source.split(oldRows).length - 1;
-  if (count !== 1) throw new Error("Potion detail rows expected one match, found " + count);
-  source = source.replace(oldRows, newRows);
+  const originalCount = source.split(originalRows).length - 1;
+  const patchedCount = source.split(previouslyPatchedRows).length - 1;
+  if (originalCount + patchedCount !== 1) {
+    throw new Error("Potion detail rows expected one supported match, found " + (originalCount + patchedCount));
+  }
+  source = originalCount === 1
+    ? source.replace(originalRows, newRows)
+    : source.replace(previouslyPatchedRows, newRows);
 
   fs.writeFileSync(filePath, source, "utf8");
   console.log("Applied merchant-crafted alchemy details to ItemCard.");
@@ -58,6 +83,13 @@ if (!source.includes("saveLabel: saveDc ?")) {
   console.log("Merchant-crafted alchemy ItemCard details already present.");
 }
 
-for (const token of ["craft.duration || result.duration || alchemy.duration", "saveLabel: saveDc ?", "<strong>Save:</strong>", "<strong>Doses:</strong>"]) {
+for (const token of [
+  "craft.duration || result.duration || alchemy.duration",
+  "saveLabel: saveDc ?",
+  "ingredientLine",
+  "<strong>Save:</strong>",
+  "<strong>Doses:</strong>",
+  "<strong>Brewed With:</strong>",
+]) {
   if (!source.includes(token)) throw new Error("ItemCard alchemy details validation failed: " + token);
 }

--- a/sql/20260616_104_merchant_alchemy_duration_qualifiers_v3.sql
+++ b/sql/20260616_104_merchant_alchemy_duration_qualifiers_v3.sql
@@ -1,1 +1,88 @@
--- Merchant alchemy duration qualifier preservation v3
+-- Mirrors live migration merchant_alchemy_duration_qualifiers_v3.
+create or replace function private.merchant_alchemy_duration_v1(
+  p_duration text,
+  p_duration_pct numeric default 0,
+  p_die_steps integer default 0
+)
+returns text
+language plpgsql
+immutable
+set search_path = pg_catalog, public, private
+as $$
+declare
+  v text := nullif(btrim(p_duration), '');
+  m text[];
+  units text[] := array['round','minute','hour','day','week'];
+  unit_seconds bigint[] := array[6,60,3600,86400,604800];
+  unit_name text;
+  suffix text := '';
+  idx integer;
+  amount numeric;
+  die_size integer;
+  seconds bigint;
+  major bigint;
+  minor bigint;
+  rendered text;
+begin
+  if v is null then return 'Until used'; end if;
+  if v ~* '^(instant|instantaneous|until\b)' then
+    return regexp_replace(v, '^instantaneous$', 'Instant', 'i');
+  end if;
+
+  m := regexp_match(
+    v,
+    '^((\d+)d(\d+)|(\d+(?:\.\d+)?))\s*(round|minute|hour|day|week)s?(\s+.*)?$',
+    'i'
+  );
+  if m is null then return v; end if;
+
+  unit_name := lower(m[5]);
+  suffix := coalesce(m[6], '');
+  idx := greatest(1, least(5,
+    coalesce(array_position(units, unit_name), 1)
+    + greatest(0, coalesce(p_die_steps, 0))
+  ));
+
+  if m[2] is not null then
+    amount := greatest(1, ceil(
+      m[2]::numeric * (1 + greatest(0, coalesce(p_duration_pct, 0)) / 100.0)
+      - 0.000000001
+    ));
+    die_size := m[3]::integer;
+    return amount::integer::text || 'd' || die_size::text || ' ' || units[idx]
+      || case when amount = 1 then '' else 's' end || suffix;
+  end if;
+
+  amount := m[4]::numeric;
+  seconds := greatest(1, round(
+    amount * unit_seconds[idx]
+    * (1 + greatest(0, coalesce(p_duration_pct, 0)) / 100.0)
+  )::bigint);
+
+  if seconds >= 604800 then
+    major := seconds / 604800;
+    minor := (seconds % 604800) / 86400;
+    rendered := major || ' week' || case when major = 1 then '' else 's' end
+      || case when minor > 0 then ' ' || minor || ' day' || case when minor = 1 then '' else 's' end else '' end;
+  elsif seconds >= 86400 then
+    major := seconds / 86400;
+    minor := (seconds % 86400) / 3600;
+    rendered := major || ' day' || case when major = 1 then '' else 's' end
+      || case when minor > 0 then ' ' || minor || ' hour' || case when minor = 1 then '' else 's' end else '' end;
+  elsif seconds >= 3600 then
+    major := seconds / 3600;
+    minor := (seconds % 3600) / 60;
+    rendered := major || ' hour' || case when major = 1 then '' else 's' end
+      || case when minor > 0 then ' ' || minor || ' minute' || case when minor = 1 then '' else 's' end else '' end;
+  elsif seconds >= 60 then
+    major := seconds / 60;
+    minor := seconds % 60;
+    rendered := major || ' minute' || case when major = 1 then '' else 's' end
+      || case when minor > 0 then ' ' || minor || ' second' || case when minor = 1 then '' else 's' end else '' end;
+  else
+    rendered := seconds || ' second' || case when seconds = 1 then '' else 's' end;
+  end if;
+
+  return rendered || suffix;
+end;
+$$;

--- a/sql/20260616_104_merchant_alchemy_duration_qualifiers_v3.sql
+++ b/sql/20260616_104_merchant_alchemy_duration_qualifiers_v3.sql
@@ -1,0 +1,1 @@
+-- Merchant alchemy duration qualifier preservation v3


### PR DESCRIPTION
## Purpose

Finish the merchant-crafted alchemy work on top of the current `main` branch without introducing a second ItemCard source rewriter.

## Changes

- Records the live `merchant_alchemy_duration_qualifiers_v3` database correction as an idempotent SQL migration.
- Scales the leading duration while preserving qualifiers such as `or 3 uses` and `after application`.
- Extends the existing canonical `patch_itemcard_alchemy_details.mjs` transform.
- Displays `Brewed With` from top-level, nested alchemy-result, or merchant-craft payload fields.
- Supports both clean ItemCard source and source previously transformed by the older patch.
- Keeps the transform idempotent.

## Validation

- Live Supabase migration version: `20260616221221`.
- Verified duration cases include `2 hours or 3 uses`, `2 minutes after application`, `2d4 hours or until discharged`, and `2 days 6 hours or 3 uses`.
- ItemCard transform passed clean-source and incremental-upgrade tests.
- Second transform run produced no file changes.
- Generated helper symbol audit passed.

## Guardrails

- No world-map, movement, route, simulation, weather, camping, or world-time files changed.
- No town/city-map behavior changed.
- No inventory or merchant-stock rows were rewritten.
- PR #20 is intentionally not reused because it is based on an outdated `main` and adds a competing ItemCard transformer.