### PR TITLE
Finish canonical A/B/C enchanting workflow

### DIFF
--- a/.github/workflows/validate-enchanting.yml
+++ b/.github/workflows/validate-enchanting.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "utils/enchanting.js"
+      - "scripts/test_enchanting_model.mjs"
       - "scripts/patch_enchanting_workshop.mjs"
       - "scripts/patch_enchanting_catalog_consistency.mjs"
       - "scripts/patch_professions_canonical_crafting.mjs"
@@ -36,9 +37,13 @@ jobs:
       - name: Validate JavaScript transformer syntax
         run: |
           node --check utils/enchanting.js
+          node --check scripts/test_enchanting_model.mjs
           node --check scripts/patch_enchanting_workshop.mjs
           node --check scripts/patch_enchanting_catalog_consistency.mjs
           node --check scripts/patch_professions_canonical_crafting.mjs
+
+      - name: Run A/B/C enchanting model tests
+        run: node scripts/test_enchanting_model.mjs
 
       - name: Validate migration safety markers
         run: |

--- a/.github/workflows/validate-enchanting.yml
+++ b/.github/workflows/validate-enchanting.yml
@@ -9,6 +9,7 @@ on:
       - "scripts/test_enchanting_model.mjs"
       - "scripts/patch_enchanting_workshop.mjs"
       - "scripts/patch_enchanting_catalog_consistency.mjs"
+      - "scripts/canonicalize_weapon_enchants.mjs"
       - "scripts/patch_professions_canonical_crafting.mjs"
       - "sql/20260617_01_enchanting_completion_v1.sql"
       - ".github/workflows/validate-enchanting.yml"
@@ -40,6 +41,7 @@ jobs:
           node --check scripts/test_enchanting_model.mjs
           node --check scripts/patch_enchanting_workshop.mjs
           node --check scripts/patch_enchanting_catalog_consistency.mjs
+          node --check scripts/canonicalize_weapon_enchants.mjs
           node --check scripts/patch_professions_canonical_crafting.mjs
 
       - name: Run A/B/C enchanting model tests
@@ -54,6 +56,10 @@ jobs:
 
       - name: Apply source transformers once
         run: npm run prebuild
+
+      - name: Verify canonical Weapon of enchantments
+        run: |
+          node -e 'const fs=require("fs"); const data=JSON.parse(fs.readFileSync("public/items/magicvariants.json","utf8")); const byKey=new Map(data.variants.map(v=>[v.key,v])); const expected={sharpness:"Weapon of Sharpness",life_stealing:"Weapon of Life Stealing",wounding:"Weapon of Wounding",vengeance:"Weapon of Vengeance"}; for(const [key,name] of Object.entries(expected)){const v=byKey.get(key); if(!v||v.name!==name) throw new Error(key+" name mismatch"); if(v.requires?.weaponFamily?.map(String).map(s=>s.toLowerCase()).includes("sword")) throw new Error(key+" still sword-only");} const sharp=byKey.get("sharpness"); if(!sharp.requires?.damageType?.map(String).map(s=>s.toLowerCase()).includes("slashing")) throw new Error("Sharpness lost slashing restriction");'
 
       - name: Stage first-pass generated sources
         run: git add --all

--- a/.github/workflows/validate-enchanting.yml
+++ b/.github/workflows/validate-enchanting.yml
@@ -1,0 +1,68 @@
+name: Validate enchanting workshop
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "utils/enchanting.js"
+      - "scripts/patch_enchanting_workshop.mjs"
+      - "scripts/patch_enchanting_catalog_consistency.mjs"
+      - "scripts/patch_professions_canonical_crafting.mjs"
+      - "sql/20260617_01_enchanting_completion_v1.sql"
+      - ".github/workflows/validate-enchanting.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate JavaScript transformer syntax
+        run: |
+          node --check utils/enchanting.js
+          node --check scripts/patch_enchanting_workshop.mjs
+          node --check scripts/patch_enchanting_catalog_consistency.mjs
+          node --check scripts/patch_professions_canonical_crafting.mjs
+
+      - name: Validate migration safety markers
+        run: |
+          grep -q "complete_enchanting_craft_plan_v1_impl" sql/20260617_01_enchanting_completion_v1.sql
+          grep -q "target_inventory_item_id" sql/20260617_01_enchanting_completion_v1.sql
+          grep -q "v_next_slots" sql/20260617_01_enchanting_completion_v1.sql
+          grep -q "private.complete_craft_plan_v1_impl" sql/20260617_01_enchanting_completion_v1.sql
+
+      - name: Apply source transformers once
+        run: npm run prebuild
+
+      - name: Stage first-pass generated sources
+        run: git add --all
+
+      - name: Verify second transformer pass is idempotent
+        run: |
+          npm run prebuild
+          git diff --exit-code
+
+      - name: Build production application
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: validation-placeholder
+        run: npm run build
+
+      - name: Verify build did not mutate generated sources
+        run: git diff --exit-code

--- a/scripts/canonicalize_weapon_enchants.mjs
+++ b/scripts/canonicalize_weapon_enchants.mjs
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const catalogPath = path.join(process.cwd(), "public", "items", "magicvariants.json");
+const catalog = JSON.parse(fs.readFileSync(catalogPath, "utf8"));
+const variants = Array.isArray(catalog?.variants) ? catalog.variants : [];
+const broadenedKeys = new Set(["sharpness", "life_stealing", "wounding", "vengeance"]);
+const expectedNames = new Map([
+  ["sharpness", "Weapon of Sharpness"],
+  ["life_stealing", "Weapon of Life Stealing"],
+  ["wounding", "Weapon of Wounding"],
+  ["vengeance", "Weapon of Vengeance"],
+]);
+let changed = false;
+
+for (const variant of variants) {
+  const key = String(variant?.key || "");
+  if (!broadenedKeys.has(key)) continue;
+
+  const expectedName = expectedNames.get(key);
+  if (variant.name !== expectedName) {
+    variant.name = expectedName;
+    changed = true;
+  }
+
+  const requires = variant.requires && typeof variant.requires === "object" && !Array.isArray(variant.requires)
+    ? { ...variant.requires }
+    : null;
+  const families = Array.isArray(requires?.weaponFamily)
+    ? requires.weaponFamily.map((value) => String(value).toLowerCase())
+    : [];
+
+  if (requires && families.length === 1 && families[0] === "sword") {
+    delete requires.weaponFamily;
+    if (Object.keys(requires).length) variant.requires = requires;
+    else delete variant.requires;
+    changed = true;
+  }
+}
+
+for (const [key, expectedName] of expectedNames) {
+  const variant = variants.find((entry) => entry?.key === key);
+  if (!variant) throw new Error(`Missing enchanting variant: ${key}`);
+  if (variant.name !== expectedName) throw new Error(`${key} must be named ${expectedName}`);
+  if (Array.isArray(variant.requires?.weaponFamily) && variant.requires.weaponFamily.some((value) => String(value).toLowerCase() === "sword")) {
+    throw new Error(`${key} must not retain a sword-only family requirement`);
+  }
+}
+
+const sharpness = variants.find((entry) => entry?.key === "sharpness");
+if (!Array.isArray(sharpness?.requires?.damageType) || !sharpness.requires.damageType.some((value) => String(value).toLowerCase() === "slashing")) {
+  throw new Error("Weapon of Sharpness must retain its Slashing damage requirement");
+}
+
+if (!Array.isArray(catalog.notes)) catalog.notes = [];
+const note = "Legacy Sword of Sharpness, Life Stealing, Wounding, and Vengeance patterns are canonical Weapon of variants. Their sword-only family gates are removed, while genuine damage-type restrictions remain.";
+if (!catalog.notes.includes(note)) {
+  catalog.notes.push(note);
+  changed = true;
+}
+
+if (catalog.updated !== "2026-06-17T00:00:00Z") {
+  catalog.updated = "2026-06-17T00:00:00Z";
+  changed = true;
+}
+
+if (changed) {
+  fs.writeFileSync(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`, "utf8");
+  console.log("Canonicalized legacy Sword of enchantments as Weapon of patterns.");
+} else {
+  console.log("Weapon enchantment names and compatibility are already canonical.");
+}

--- a/scripts/patch_enchanting_catalog_consistency.mjs
+++ b/scripts/patch_enchanting_catalog_consistency.mjs
@@ -1,0 +1,19 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const target = path.join(process.cwd(), "pages", "items.js");
+let source = fs.readFileSync(target, "utf8");
+const before = '  const variant = { ...raw, key, name: normalizedName, originalName, appliesTo };';
+const after = '  const variant = { ...raw, entries: raw.textByKind ? [] : entries, key, name: normalizedName, originalName, appliesTo };';
+
+if (!source.includes(after)) {
+  const count = source.split(before).length - 1;
+  if (count !== 1) throw new Error(`Enchanting catalog consistency patch expected one variant match, found ${count}`);
+  source = source.replace(before, after);
+  fs.writeFileSync(target, source, "utf8");
+  console.log("Preferred item-specific textByKind enchanting rules over conflicting legacy entry summaries.");
+} else {
+  console.log("Enchanting catalog consistency patch already present.");
+}
+
+if (!source.includes(after)) throw new Error("Enchanting catalog consistency validation failed");

--- a/scripts/patch_enchanting_workshop.mjs
+++ b/scripts/patch_enchanting_workshop.mjs
@@ -1,0 +1,561 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function replaceOnce(source, before, after, label) {
+  const count = source.split(before).length - 1;
+  if (count !== 1) throw new Error(`${label}: expected one match, found ${count}`);
+  return source.replace(before, after);
+}
+
+function replaceRegexOnce(source, regex, after, label) {
+  const matches = source.match(regex);
+  if (!matches) throw new Error(`${label}: no match`);
+  const duplicateCheck = source.slice((matches.index || 0) + matches[0].length).match(regex);
+  if (duplicateCheck) throw new Error(`${label}: more than one match`);
+  return source.replace(regex, after);
+}
+
+const itemPath = path.join(process.cwd(), "pages", "items.js");
+let source = fs.readFileSync(itemPath, "utf8");
+const marker = "buildEnchantingPreview";
+
+if (!source.includes(marker)) {
+  source = replaceOnce(
+    source,
+    `import {
+  buildCrafterProfessionSnapshot,
+  professionForDiscipline,
+  providerOffersProfession,
+} from "../utils/craftingProfessions";`,
+    `import {
+  buildCrafterProfessionSnapshot,
+  professionForDiscipline,
+  providerOffersProfession,
+} from "../utils/craftingProfessions";
+import {
+  ENCHANTING_SLOT_ORDER,
+  ENCHANTING_SLOT_RULES,
+  buildEnchantingPreview,
+  enchantingCatalystEffect,
+  enchantingRecipeDisabledReason,
+  enchantingRecipeOptions,
+  enchantingRequirementCheck,
+  enchantingSlotForRecipe,
+  isEnchantingCatalyst,
+  isEnchantingRecipeFuture,
+  resolveEnchantingRecipeRarity,
+} from "../utils/enchanting";`,
+    "Enchanting helper imports"
+  );
+
+  const variantFunction = `function variantRecipe(raw) {
+  const key = String(raw?.key || raw?.name || "").toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  const originalName = String(raw?.name || "").trim();
+  if (!key || !originalName || PHYSICAL_VARIANTS.has(key)) return null;
+  const appliesTo = Array.isArray(raw.appliesTo) ? raw.appliesTo.map((value) => String(value).toLowerCase()) : ["weapon", "armor", "shield", "ammunition"];
+  const entries = Array.isArray(raw.entries) ? raw.entries : raw.entries ? [String(raw.entries)] : [];
+  const options = Array.isArray(raw.options) ? raw.options : [];
+  const normalizedName = originalName.replace(/^Sword of\s+/i, "Weapon of ");
+  const variant = { ...raw, key, name: normalizedName, originalName, appliesTo };
+  const recipeRarity = rarity(raw.rarity || (raw.rarityByValue ? "Varies" : "")) || "Varies";
+  const recipeShell = { key, name: normalizedName, rarity: recipeRarity, variant };
+  const targetSlot = enchantingSlotForRecipe(recipeShell);
+  const future = isEnchantingRecipeFuture(recipeShell);
+  const disabledReason = future ? enchantingRecipeDisabledReason(recipeShell) : "";
+  const firstKind = appliesTo[0] || "weapon";
+  const effectPreview = raw.textByKind?.[firstKind] || raw.textByKind?.weapon || raw.textByKind?.armor || raw.textByKind?.shield || raw.textByKind?.ammunition || entries.join(" ");
+  const slotRule = targetSlot ? ENCHANTING_SLOT_RULES[targetSlot] : null;
+  return {
+    id: \`enchant:\${key}\`,
+    key,
+    name: normalizedName,
+    originalName,
+    discipline: "Enchanting",
+    kind: "enchant",
+    category: appliesTo.join(" / "),
+    family: appliesTo.includes("weapon") ? "Weapon" : appliesTo.map(titleCase).join(" / "),
+    applies_to: appliesTo,
+    rarity: recipeRarity,
+    known: false,
+    source: raw.source || "Variant Catalog",
+    summary: effectPreview || \`Magical trait applicable to \${appliesTo.join(", ")}.\`,
+    effect_text: effectPreview || "",
+    entries,
+    options,
+    requires: raw.requires || {},
+    text_by_kind: raw.textByKind || {},
+    variant,
+    slot_key: targetSlot || null,
+    craft_disabled: future,
+    disabled_reason: disabledReason,
+    requirements: future
+      ? [disabledReason]
+      : [\`Smith-tiered base item with \${slotRule?.label || "an available slot"} unlocked\`, \`Applies to: \${appliesTo.join(", ")}\`],
+    components: future
+      ? ["Future enchanting content"]
+      : [\`One \${slotRule?.minimumCatalystRarity || "Common"} or better arcane catalyst\`, ...(options.length ? [\`Choose option: \${options.join(", ")}\`] : [])],
+  };
+}`;
+  source = replaceRegexOnce(
+    source,
+    /function variantRecipe\(raw\) \{[\s\S]*?\n\}\n\nconst ALCHEMY_POTION_FORMULAS/,
+    `${variantFunction}\n\nconst ALCHEMY_POTION_FORMULAS`,
+    "Variant recipe normalization"
+  );
+
+  source = replaceRegexOnce(
+    source,
+    /function isCraftBaseCandidate\(item, recipe\) \{[\s\S]*?\n\}\nfunction characterName/,
+    `function isCraftBaseCandidate(item, recipe) {
+  if (!item || !recipe) return false;
+  const blob = [item.name, item.type, item.rarity, item.payload?.item_type, item.payload?.type, item.payload?.uiType].filter(Boolean).join(" ").toLowerCase();
+  const physical = /(weapon|armor|shield|ammunition|melee|ranged)/.test(blob);
+  if (recipe.kind === "forge" || recipe.kind === "alchemy" || recipe.discipline === "Alchemy") return false;
+  if (recipe.discipline === "Smithing") {
+    if (!physical) return false;
+    if (recipe.kind !== "temper") return true;
+    if (recipe.progressive_temper || recipe.id === "temper:progression") return nextTemperStageForItem(item) <= 3;
+    const targetTier = Math.max(0, Math.min(3, temperTierForRecipe(recipe, item)));
+    const currentTier = physicalEnhancementTier(item);
+    if (targetTier === 0) return currentTier === 0 && !smithingHistoryFromItem(item)["initial-temper"];
+    if (currentTier !== targetTier - 1) return false;
+    return !smithingHistoryFromItem(item)[\`temper-\${targetTier}\`];
+  }
+  if (recipe.discipline === "Enchanting") return enchantingRequirementCheck(item, recipe, recipe.selected_option).ok;
+  return true;
+}
+function characterName`,
+    "Enchanting base-item validation"
+  );
+
+  source = replaceOnce(
+    source,
+    `function suggestedResultName(recipe, baseItem) {
+  if (!recipe) return "";
+  if (recipe.kind === "forge") return recipe.name.replace(/^Forge\\s+/i, "");
+  if (recipe.kind === "temper" && baseItem?.name) { const stage = Math.max(0, Math.min(3, temperTierForRecipe(recipe, baseItem))); const cleanName = baseItem.name.replace(/^\\+\\d+\\s+/i, ""); return stage === 0 ? \`Tempered \${cleanName}\` : \`+\${stage} \${cleanName}\`; }
+  if (recipe.discipline === "Enchanting" && baseItem?.name) return \`\${recipe.name} \${baseItem.name}\`.trim();
+  return baseItem?.name || recipe.name;
+}`,
+    `function suggestedResultName(recipe, baseItem) {
+  if (!recipe) return "";
+  if (recipe.kind === "forge") return recipe.name.replace(/^Forge\\s+/i, "");
+  if (recipe.kind === "temper" && baseItem?.name) { const stage = Math.max(0, Math.min(3, temperTierForRecipe(recipe, baseItem))); const cleanName = baseItem.name.replace(/^\\+\\d+\\s+/i, ""); return stage === 0 ? \`Tempered \${cleanName}\` : \`+\${stage} \${cleanName}\`; }
+  if (recipe.discipline === "Enchanting" && baseItem) return buildEnchantingPreview(recipe, baseItem, recipe.selected_option, null)?.finalName || baseItem.name;
+  return baseItem?.name || recipe.name;
+}`,
+    "Enchanting result naming"
+  );
+
+  source = replaceRegexOnce(
+    source,
+    /function recipeSlotLabel\(recipe\) \{[\s\S]*?\n\}\nfunction RecipeTable/,
+    `function recipeSlotLabel(recipe) {
+  if (!recipe || recipe.discipline !== "Enchanting") return "—";
+  return enchantingSlotForRecipe(recipe, recipe.selected_option) || "Future";
+}
+function RecipeTable`,
+    "Exact A/B/C slot labels"
+  );
+
+  source = replaceOnce(source, `                onDoubleClick={() => onCraft?.(recipe)}`, `                onDoubleClick={() => { if (!recipe.craft_disabled) onCraft?.(recipe); }}`, "Disable future recipe double-click");
+  source = replaceOnce(
+    source,
+    `                    className={cls("craft-row-craft-button", craftingRecipeId === recipe.id && "active")}
+                    onClick={(event) => { event.stopPropagation(); onCraft?.(recipe); }}
+                    title="Open this recipe's ingredient selector"
+                  >
+                    {craftingRecipeId === recipe.id ? "Back" : "Craft"}`,
+    `                    className={cls("craft-row-craft-button", craftingRecipeId === recipe.id && "active")}
+                    onClick={(event) => { event.stopPropagation(); if (!recipe.craft_disabled) onCraft?.(recipe); }}
+                    title={recipe.craft_disabled ? recipe.disabled_reason || "Future enchanting content" : "Open this recipe's ingredient selector"}
+                    disabled={Boolean(recipe.craft_disabled)}
+                  >
+                    {recipe.craft_disabled ? "Future" : craftingRecipeId === recipe.id ? "Back" : "Craft"}`,
+    "Disable future recipe craft button"
+  );
+
+  source = replaceOnce(
+    source,
+    `function recipeWithSmithingResult(recipe = {}, preview = null) {`,
+    `function recipeWithEnchantingResult(recipe = {}, preview = null) {
+  if (recipe?.discipline !== "Enchanting" || !preview) return recipe;
+  return {
+    ...recipe,
+    rarity: preview.outputRarity || recipe.rarity,
+    selected_option: preview.variant?.option ?? recipe.selected_option ?? null,
+    effect_text: preview.effectText || recipe.effect_text || recipe.summary,
+    entries: preview.finalEntries || recipe.entries || [],
+    item_description: (preview.finalEntries || []).join("\\n"),
+    enchanting_result: preview,
+  };
+}
+function recipeWithSmithingResult(recipe = {}, preview = null) {`,
+    "Enchanting recipe payload helper"
+  );
+
+  source = replaceOnce(
+    source,
+    `  const effect = slot?.temper_elemental
+    ? temperMaterialEffect(material, slot, baseItem, recipe)
+    : smithingMaterialEffect(material, baseItem, recipe) || materialEffectFor(material, materialEffects) || fallbackMaterialEffect(material) || {`,
+    `  const effect = discipline === "Enchanting"
+    ? enchantingCatalystEffect(material, recipe, slot?.enchanting_slot, recipe?.selected_option)
+    : slot?.temper_elemental
+      ? temperMaterialEffect(material, slot, baseItem, recipe)
+      : smithingMaterialEffect(material, baseItem, recipe) || materialEffectFor(material, materialEffects) || fallbackMaterialEffect(material) || {`,
+    "Enchanting catalyst card effect"
+  );
+
+  source = replaceOnce(source, `  const [selectedMaterials, setSelectedMaterials] = useState({});
+  const [crafterCharacterId, setCrafterCharacterId] = useState("");`, `  const [selectedMaterials, setSelectedMaterials] = useState({});
+  const [enchantOption, setEnchantOption] = useState("");
+  const [crafterCharacterId, setCrafterCharacterId] = useState("");`, "Enchanting option state");
+  source = replaceOnce(source, `    setSelectedMaterials({});
+    setCrafterCharacterId("");`, `    setSelectedMaterials({});
+    setEnchantOption("");
+    setCrafterCharacterId("");`, "Enchanting option reset");
+
+  source = replaceRegexOnce(
+    source,
+    /  const reqs = \(recipe\.requirements \|\| \[\]\)\.filter\(Boolean\);[\s\S]*?  const destructiveSelectedMaterials = destructiveMaterialsFromSelection\(selectedMaterials, plan\);/,
+    `  const enchantOptions = recipe.discipline === "Enchanting" ? enchantingRecipeOptions(recipe) : [];
+  const effectiveEnchantOption = enchantOption === "" ? null : enchantOption;
+  const resolvedEnchantRarity = recipe.discipline === "Enchanting" ? resolveEnchantingRecipeRarity(recipe, effectiveEnchantOption) : recipe.rarity;
+  const planningRecipe = recipe.discipline === "Enchanting" ? { ...recipe, rarity: resolvedEnchantRarity, selected_option: effectiveEnchantOption } : recipe;
+  const reqs = (planningRecipe.requirements || []).filter(Boolean);
+  const comps = (planningRecipe.components || []).filter(Boolean);
+  const alchemyDetails = alchemyFormulaDetails(planningRecipe);
+  const workflow = craftingWorkflowCopy(planningRecipe);
+  const workflowTheme = workflow.theme;
+  const allPlanningResources = resourceCatalog.length ? resourceCatalog : materials;
+  const planningResources = allPlanningResources.filter((material) => materialAllowedForRecipe(material, planningRecipe));
+  const normalizedInventory = inventoryItems.map(normalizeBenchInventoryItem);
+  const createsNewItem = recipeCreatesNewItem(planningRecipe);
+  const baseCandidates = createsNewItem ? [] : normalizedInventory.filter((item) => isCraftBaseCandidate(item, planningRecipe));
+  const baseItem = createsNewItem ? null : baseCandidates.find((item) => String(item.id) === String(baseItemId)) || null;
+  const rawPlan = buildCraftBenchPlan(planningRecipe, planningResources, baseItem);
+  const plan = planningRecipe.discipline === "Smithing" && baseItem ? hydrateSmithingPlanWithExisting(rawPlan, baseItem) : rawPlan;
+  const targetCharacter = characters.find((character) => String(character.id) === String(targetCharacterId)) || null;
+  const professionKey = professionForDiscipline(planningRecipe.discipline);
+  const isNpcAssisted = Boolean(crafterContext?.character);
+  const selfCrafterCandidates = characters.filter((character) => character?.kind === "player" || character?.target_type === "player");
+  const selfCrafter = !isNpcAssisted ? selfCrafterCandidates.find((character) => String(character.id) === String(crafterCharacterId)) || null : null;
+  const activeCrafterCharacter = isNpcAssisted ? crafterContext.character : selfCrafter;
+  const activeCrafterSheet = isNpcAssisted ? crafterContext.sheet || {} : selfCrafter?.character_sheet || {};
+  const crafterSnapshot = activeCrafterCharacter && professionKey ? buildCrafterProfessionSnapshot(activeCrafterCharacter, activeCrafterSheet, professionKey) : null;
+  const providerOffersRequestedProfession = !isNpcAssisted || providerOffersProfession(crafterContext.character, professionKey);
+  const providerTownValid = !isNpcAssisted || crafterContext?.townValid !== false;
+  const providerValid = !isNpcAssisted || Boolean(providerOffersRequestedProfession && providerTownValid);
+  const craftingActorValid = Boolean(activeCrafterCharacter && crafterSnapshot?.configured && providerValid);
+  const enteredCraftRoll = Number(craftRollTotal);
+  const resolvedCraftRollTotal = craftRollTotal !== "" ? enteredCraftRoll + Number(crafterSnapshot?.total_modifier || 0) : enteredCraftRoll;
+  const effectiveCrafterProficiency = Number(crafterSnapshot?.proficiency_bonus || 0);
+  const outputQuantity = recipeOutputQuantity(planningRecipe);
+  const selectedMaterialObjectsForPreview = selectedMaterialObjects(selectedMaterials, plan);
+  const selectedEnchantingCatalyst = planningRecipe.discipline === "Enchanting" ? selectedMaterialObjectsForPreview.find((material) => material.enchanting_catalyst) || null : null;
+  const enchantingPreview = planningRecipe.discipline === "Enchanting" && baseItem ? buildEnchantingPreview(planningRecipe, baseItem, effectiveEnchantOption, selectedEnchantingCatalyst) : null;
+  const rawAttemptPreview = calculateCraftAttemptPreview(planningRecipe, plan, selectedMaterials, recipeRules, materialEffects, baseItem);
+  const attemptPreview = applySmithingAttemptPreview(planningRecipe, rawAttemptPreview, selectedMaterialObjectsForPreview);
+  const smithingPreview = smithingProductPreview(planningRecipe, baseItem, selectedMaterialObjectsForPreview);
+  const alchemyQualityPreview = planningRecipe.discipline === "Alchemy" ? alchemyBrewQualityPreview(planningRecipe, selectedMaterialObjectsForPreview) : null;
+  const alchemyPreviewRecipe = alchemyQualityPreview ? { ...planningRecipe, formula_rarity: alchemyQualityPreview.formulaRarity, rarity: alchemyQualityPreview.finishedRarity } : planningRecipe;
+  const displayedResultName = resultItemName || enchantingPreview?.finalName || dynamicAlchemyResultName(planningRecipe, selectedMaterialObjectsForPreview) || suggestedResultName(planningRecipe, baseItem) || planningRecipe.name;
+  const alchemyProductPreview = alchemyDetails ? buildAlchemyProductPreview(planningRecipe, alchemyDetails, selectedMaterialObjectsForPreview, attemptPreview, outputQuantity, { crafterProficiency: effectiveCrafterProficiency, craftRollTotal: resolvedCraftRollTotal }) : null;
+  const finalOutputQuantity = alchemyProductPreview?.outputQuantity || outputQuantity;
+  const selectedMaterialList = selectedMaterialPayload(selectedMaterials, plan);
+  const selectedMaterialCount = selectedMaterialList.filter((material) => material.name).length;
+  const destructiveSelectedMaterials = destructiveMaterialsFromSelection(selectedMaterials, plan);
+  const enchantingOptionRequired = planningRecipe.discipline === "Enchanting" && enchantOptions.length > 0;
+  const enchantingOptionReady = !enchantingOptionRequired || effectiveEnchantOption !== null;
+  const enchantingRecipeReady = planningRecipe.discipline !== "Enchanting" || Boolean(enchantingPreview?.valid && enchantingOptionReady);`,
+    "Enchanting preview derivation"
+  );
+
+  source = replaceOnce(
+    source,
+    `    if (!recipe) {
+      setPlanError("Choose a recipe before submitting a craft attempt.");
+      return;
+    }
+    const enteredRoll = Number(craftRollTotal);`,
+    `    if (!recipe) {
+      setPlanError("Choose a recipe before submitting a craft attempt.");
+      return;
+    }
+    if (planningRecipe.discipline === "Enchanting") {
+      if (isEnchantingRecipeFuture(planningRecipe, effectiveEnchantOption)) {
+        setPlanError(enchantingRecipeDisabledReason(planningRecipe, effectiveEnchantOption));
+        return;
+      }
+      if (enchantingOptionRequired && !enchantingOptionReady) {
+        setPlanError("Choose the enchantment option before submitting this craft attempt.");
+        return;
+      }
+      if (!baseItem) {
+        setPlanError("Choose the smith-tiered item that will be replaced by the enchanted result.");
+        return;
+      }
+      if (!enchantingPreview?.requirement?.ok) {
+        setPlanError(enchantingPreview?.requirement?.reason || "The selected item is not compatible with this enchantment.");
+        return;
+      }
+      if (!selectedEnchantingCatalyst) {
+        setPlanError(\`Choose a compatible catalyst for Slot \${enchantingPreview?.slot || recipeSlotLabel(planningRecipe)}.\`);
+        return;
+      }
+    }
+    const enteredRoll = Number(craftRollTotal);`,
+    "Enchanting submit validation"
+  );
+
+  source = replaceOnce(
+    source,
+    `      const recipeForPayload = recipeWithSmithingResult(recipe, smithingPreview);
+      const basePayload = craftPlanInsertPayload(recipeForPayload, plan, {
+        targetCharacter,
+        baseItem,
+        selectedMaterials,
+        resultItemName: displayedResultName,
+        automationPreview: { ...attemptPreview, output_quantity: finalOutputQuantity, final_effect_preview: alchemyProductPreview || smithingPreview },
+      });`,
+    `      const recipeForPayload = recipeWithEnchantingResult(recipeWithSmithingResult(planningRecipe, smithingPreview), enchantingPreview);
+      const basePayload = craftPlanInsertPayload(recipeForPayload, plan, {
+        targetCharacter,
+        baseItem,
+        selectedMaterials,
+        resultItemName: displayedResultName,
+        enchantingPreview,
+        automationPreview: { ...attemptPreview, output_quantity: finalOutputQuantity, final_effect_preview: enchantingPreview || alchemyProductPreview || smithingPreview, enchanting: enchantingPreview },
+      });`,
+    "Enchanting craft-plan payload"
+  );
+
+  source = replaceOnce(
+    source,
+    `        <span className={cls("craft-preview-rarity", \`rarity-\${String(alchemyProductPreview?.finishedRarity || recipe.rarity || "varies").toLowerCase().replace(/\\s+/g, "-")}\`)}>{alchemyProductPreview?.finishedRarity || recipe.rarity || "—"}</span>`,
+    `        <span className={cls("craft-preview-rarity", \`rarity-\${String(enchantingPreview?.outputRarity || alchemyProductPreview?.finishedRarity || planningRecipe.rarity || "varies").toLowerCase().replace(/\\s+/g, "-")}\`)}>{enchantingPreview?.outputRarity || alchemyProductPreview?.finishedRarity || planningRecipe.rarity || "—"}</span>`,
+    "Enchanting preview rarity"
+  );
+  source = replaceOnce(source, `        {recipe.summary || "No summary available."}`, `        {enchantingPreview?.effectText || planningRecipe.summary || "No summary available."}`, "Enchanting preview summary");
+  source = replaceOnce(
+    source,
+    `            <span className="craft-chip craft-chip-gold">Slot {recipeSlotLabel(recipe)}</span>
+            <span className={recipe.known ? "craft-chip craft-chip-green" : "craft-chip"}>{recipe.known ? "Owned / Known" : "Reference"}</span>`,
+    `            <span className="craft-chip craft-chip-gold">Slot {recipeSlotLabel(planningRecipe)}</span>
+            {planningRecipe.craft_disabled ? <span className="craft-chip craft-chip-rose">Future</span> : null}
+            <span className={planningRecipe.known ? "craft-chip craft-chip-green" : "craft-chip"}>{planningRecipe.known ? "Owned / Known" : "Reference"}</span>`,
+    "Enchanting preview chips"
+  );
+
+  source = replaceOnce(
+    source,
+    `      {alchemyDetails ? (`,
+    `      {planningRecipe.discipline === "Enchanting" ? (
+        <div className="craft-section craft-section-card craft-enchanting-result-preview mt-3">
+          <div className="craft-section-title">A/B/C Enchantment Preview</div>
+          {!baseItem ? <div className="craft-bullet muted">Choose a smith-tiered item to inspect its unlocked and occupied enchantment slots.</div> : (
+            <>
+              <div className="craft-enchant-slot-grid">
+                {ENCHANTING_SLOT_ORDER.map((slotKey) => {
+                  const unlocked = enchantingPreview?.unlockedSlots?.includes(slotKey);
+                  const previous = enchantingPreview?.existingSlots?.[slotKey] || null;
+                  const next = enchantingPreview?.nextSlots?.[slotKey] || null;
+                  const targeted = enchantingPreview?.slot === slotKey;
+                  return (
+                    <div key={slotKey} className={cls("craft-enchant-slot-card", unlocked ? "unlocked" : "locked", targeted && "targeted", targeted && previous && "replacing")}>
+                      <div className="craft-enchant-slot-head"><strong>Slot {slotKey}</strong><span>{unlocked ? targeted ? previous ? "Replace" : "Imbue" : next ? "Inherited" : "Open" : \`Requires +\${ENCHANTING_SLOT_RULES[slotKey].minimumTier}\`}</span></div>
+                      {next ? <><div className="craft-enchant-slot-name">{next.name}</div><div className="craft-enchant-slot-rarity">{next.rarity || "—"}</div></> : <div className="craft-enchant-slot-empty">{unlocked ? "No enchantment recorded" : "Locked by smith tier"}</div>}
+                      {targeted && previous ? <div className="craft-enchant-replace-note">Replaces {previous.name}; Slots {ENCHANTING_SLOT_ORDER.filter((key) => key !== slotKey).join(" and ")} remain unchanged.</div> : null}
+                    </div>
+                  );
+                })}
+              </div>
+              {enchantingPreview?.effectText ? <div className="craft-final-effect-callout mt-3"><strong>Target Slot Effect</strong><p>{enchantingPreview.effectText}</p></div> : null}
+              <div className="craft-formula-detail-grid mt-3">
+                <div><span>Physical Tier</span><strong>+{enchantingPreview?.tier || 0}</strong></div>
+                <div><span>Target Slot</span><strong>{enchantingPreview?.slotLabel || "Unavailable"}</strong></div>
+                <div><span>Catalyst</span><strong>{enchantingPreview?.catalyst?.name || "Not selected"}</strong></div>
+                <div><span>Final Rarity</span><strong>{enchantingPreview?.outputRarity || planningRecipe.rarity || "—"}</strong></div>
+              </div>
+              {enchantingPreview?.disabledReason ? <div className="craft-plan-alert danger">{enchantingPreview.disabledReason}</div> : null}
+            </>
+          )}
+        </div>
+      ) : null}
+
+      {alchemyDetails ? (`,
+    "Enchanting A/B/C preview"
+  );
+
+  source = replaceOnce(
+    source,
+    `  const requiredWorkflowSlots = (plan.matches || []).filter((slot) => slot.required !== false);
+  const selectedRequiredSlotCount = requiredWorkflowSlots.filter((slot) => selectedMaterials[materialSlotKey(slot)]).length;
+  const itemStepReady = createsNewItem || Boolean(baseItem);
+  const materialStepReady = requiredWorkflowSlots.length === 0 || selectedRequiredSlotCount === requiredWorkflowSlots.length;
+  const finalizeStepReady = itemStepReady && materialStepReady;`,
+    `  const requiredWorkflowSlots = (plan.matches || []).filter((slot) => slot.required !== false);
+  const selectedRequiredSlotCount = requiredWorkflowSlots.filter((slot) => selectedMaterials[materialSlotKey(slot)]).length;
+  const itemStepReady = createsNewItem || Boolean(baseItem && (planningRecipe.discipline !== "Enchanting" || enchantingPreview?.requirement?.ok));
+  const materialStepReady = (requiredWorkflowSlots.length === 0 || selectedRequiredSlotCount === requiredWorkflowSlots.length) && enchantingOptionReady;
+  const finalizeStepReady = itemStepReady && materialStepReady && enchantingRecipeReady;`,
+    "Enchanting workflow readiness"
+  );
+
+  source = replaceOnce(
+    source,
+    `{baseItem ? <div className="craft-base-pattern-card mt-2"><div><span>Selected item</span><strong>{baseItem.name}</strong></div><span className="craft-chip">{baseItem.rarity || "Mundane"}</span></div> : <div className="craft-bullet muted mt-2">Only compatible physical gear from the selected character inventory is listed.</div>}`,
+    `{baseItem ? <div className="craft-base-pattern-card mt-2"><div><span>Selected item</span><strong>{baseItem.name}</strong>{planningRecipe.discipline === "Enchanting" ? <small>Unlocked: {enchantingPreview?.unlockedSlots?.map((slot) => \`Slot \${slot}\`).join(", ") || "No slots"}</small> : null}</div><span className="craft-chip">{baseItem.rarity || "Mundane"}</span></div> : <div className="craft-bullet muted mt-2">Only compatible physical gear from the selected character inventory is listed.</div>}`,
+    "Enchanting base-item slot summary"
+  );
+
+  source = replaceOnce(
+    source,
+    `  const ingredientFamiliesBlock = plan.matches?.length ? (`,
+    `  const enchantingOptionBlock = planningRecipe.discipline === "Enchanting" ? (
+    <div className={cls("craft-section", "craft-section-card", "craft-enchant-trait-section", \`craft-theme-\${workflowTheme}\`, "mt-3")}>
+      <div className="craft-section-title">Magical Trait</div>
+      <div className="craft-base-pattern-card"><div><span>Selected enchantment</span><strong>{planningRecipe.name}</strong><small>Targets Slot {recipeSlotLabel(planningRecipe)}</small></div><span className="craft-chip craft-chip-gold">{planningRecipe.rarity || "Varies"}</span></div>
+      {enchantOptions.length ? <label className="craft-enchant-option-field mt-2"><span>Trait option</span><select className="form-select craft-input" value={enchantOption} onChange={(event) => { setEnchantOption(event.target.value); setSelectedMaterials({}); setOpenSlotKey(""); }}><option value="">Choose an option</option>{enchantOptions.map((option) => <option key={String(option)} value={String(option)}>{titleCase(String(option))}</option>)}</select></label> : null}
+      {planningRecipe.craft_disabled ? <div className="craft-plan-alert danger">{planningRecipe.disabled_reason || enchantingRecipeDisabledReason(planningRecipe, effectiveEnchantOption)}</div> : null}
+    </div>
+  ) : null;
+
+  const ingredientFamiliesBlock = plan.matches?.length ? (`,
+    "Enchanting trait/option block"
+  );
+  source = replaceOnce(source, `          {baseItemBlock}
+          {ingredientFamiliesBlock}`, `          {baseItemBlock}
+          {enchantingOptionBlock}
+          {ingredientFamiliesBlock}`, "Render enchanting trait block");
+  source = replaceOnce(source, `      <button type="button" className="btn btn-primary mt-2 craft-primary-action" onClick={submitPreviewCraftPlan} disabled={savingPlan || !craftRollTotal || !targetCharacterId || !craftingActorValid}>`, `      <button type="button" className="btn btn-primary mt-2 craft-primary-action" onClick={submitPreviewCraftPlan} disabled={savingPlan || !craftRollTotal || !targetCharacterId || !craftingActorValid || !finalizeStepReady}>`, "Enchanting finalization guard");
+
+  source = replaceOnce(
+    source,
+    `  if (recipe?.discipline === "Smithing" && ["forge", "temper"].includes(recipe?.kind)) return temperMaterialSlotsForRecipe(recipe, baseItem);
+  const alchemySlots = alchemyMaterialSlotsForRecipe(recipe);`,
+    `  if (recipe?.discipline === "Smithing" && ["forge", "temper"].includes(recipe?.kind)) return temperMaterialSlotsForRecipe(recipe, baseItem);
+  if (recipe?.discipline === "Enchanting") {
+    const slot = enchantingSlotForRecipe(recipe, recipe.selected_option);
+    const slotRule = ENCHANTING_SLOT_RULES[slot];
+    if (!slotRule || isEnchantingRecipeFuture(recipe, recipe.selected_option)) return [];
+    return [{ key: \`enchanting-catalyst-\${slot}\`, category: "Catalyst", label: \`Slot \${slot} Arcane Catalyst\`, role: "Binding Catalyst", required: true, enchanting_catalyst: true, enchanting_slot: slot, selected_option: recipe.selected_option ?? null, min_rarity: slotRule.minimumCatalystRarity }];
+  }
+  const alchemySlots = alchemyMaterialSlotsForRecipe(recipe);`,
+    "Enchanting catalyst slot"
+  );
+
+  source = replaceOnce(source, `  if (d === "smithing" && Object.keys(profile).length) return true;
+  if (hasExplicitAlchemyPayload(material)) return false;`, `  if (d === "smithing" && Object.keys(profile).length) return true;
+  if (d === "enchanting" && isEnchantingCatalyst(material, recipe, enchantingSlotForRecipe(recipe, recipe.selected_option), recipe.selected_option)) return true;
+  if (hasExplicitAlchemyPayload(material)) return false;`, "Permit shared arcane catalysts in enchanting");
+  source = replaceOnce(source, `        if (recipe.discipline === "Alchemy") return materialMeetsAlchemySlot(material, slot);
+        if (slot.temper_elemental) return isElementalTemperMaterial(material);`, `        if (recipe.discipline === "Alchemy") return materialMeetsAlchemySlot(material, slot);
+        if (slot.enchanting_catalyst) return isEnchantingCatalyst(material, recipe, slot.enchanting_slot, recipe.selected_option);
+        if (slot.temper_elemental) return isElementalTemperMaterial(material);`, "Enchanting catalyst filtering");
+  source = replaceOnce(
+    source,
+    `        if (slot.physical_material) {
+          const availableDelta = Number(Boolean(b.is_available)) - Number(Boolean(a.is_available));`,
+    `        if (slot.enchanting_catalyst) {
+          const availableDelta = Number(Boolean(b.is_available)) - Number(Boolean(a.is_available));
+          if (availableDelta) return availableDelta;
+          const resonanceDelta = Number(enchantingCatalystEffect(b, recipe, slot.enchanting_slot, recipe.selected_option)?.affinity_tags?.length || 0) - Number(enchantingCatalystEffect(a, recipe, slot.enchanting_slot, recipe.selected_option)?.affinity_tags?.length || 0);
+          if (resonanceDelta) return resonanceDelta;
+          return (rarityRank(b.rarity) - rarityRank(a.rarity)) || String(a.name).localeCompare(String(b.name));
+        }
+        if (slot.physical_material) {
+          const availableDelta = Number(Boolean(b.is_available)) - Number(Boolean(a.is_available));`,
+    "Enchanting catalyst sorting"
+  );
+
+  source = replaceOnce(source, `      slot_type: entry.slot_type || entry.slotType || (entry.family === "any" ? "modifier" : "core"),
+      temper_elemental: Boolean(entry.temper_elemental),`, `      slot_type: entry.slot_type || entry.slotType || (entry.family === "any" ? "modifier" : "core"),
+      enchanting_catalyst: Boolean(entry.enchanting_catalyst),
+      enchanting_slot: entry.enchanting_slot || null,
+      selected_option: entry.selected_option ?? null,
+      temper_elemental: Boolean(entry.temper_elemental),`, "Enchanting selected-material payload");
+  source = replaceOnce(source, `      slot_allowed_families: entry.allowed_families || entry.allowedFamilies || [],
+      temper_elemental: Boolean(entry.temper_elemental),`, `      slot_allowed_families: entry.allowed_families || entry.allowedFamilies || [],
+      enchanting_catalyst: Boolean(entry.enchanting_catalyst),
+      enchanting_slot: entry.enchanting_slot || null,
+      selected_option: entry.selected_option ?? null,
+      temper_elemental: Boolean(entry.temper_elemental),`, "Enchanting selected-material object");
+
+  source = replaceOnce(source, `  const materialBreakdown = selected.map((material) => {
+    const alchemyEffect = isAlchemy ? alchemyMaterialSpecificEffect(material, effectiveRecipe) : null;
+    const physicalEffect = !isAlchemy && material.temper_elemental`, `  const materialBreakdown = selected.map((material) => {
+    const alchemyEffect = isAlchemy ? alchemyMaterialSpecificEffect(material, effectiveRecipe) : null;
+    const enchantingEffect = recipe?.discipline === "Enchanting" ? enchantingCatalystEffect(material, recipe, material.enchanting_slot, recipe.selected_option) : null;
+    const physicalEffect = !isAlchemy && material.temper_elemental`, "Enchanting attempt catalyst effect");
+  source = replaceOnce(source, `    const effect = alchemyEffect || physicalEffect || materialEffectFor(material, materialEffects) || fallbackMaterialEffect(material) || {`, `    const effect = alchemyEffect || enchantingEffect || physicalEffect || materialEffectFor(material, materialEffects) || fallbackMaterialEffect(material) || {`, "Use enchanting catalyst effect");
+
+  source = replaceOnce(source, `      brew_quality: options.automationPreview?.brew_quality || null,
+      created_from: "crafting_hub_draft",`, `      brew_quality: options.automationPreview?.brew_quality || null,
+      enchanting: options.enchantingPreview || null,
+      replaces_base_item: recipe?.discipline === "Enchanting",
+      created_from: "crafting_hub_draft",`, "Enchanting result payload snapshot");
+  source = replaceOnce(source, `      brew_quality: options.automationPreview?.brew_quality || null,
+    },
+  };`, `      brew_quality: options.automationPreview?.brew_quality || null,
+      enchanting: options.enchantingPreview || null,
+      replaces_base_item: recipe?.discipline === "Enchanting",
+    },
+  };`, "Enchanting plan payload snapshot");
+  source = replaceOnce(source, `    if (recipe.placeholder) {
+      setCraftingRecipeId(null);
+      return;
+    }`, `    if (recipe.placeholder || recipe.craft_disabled) {
+      setCraftingRecipeId(null);
+      return;
+    }`, "Prevent future enchantment craft mode");
+
+  fs.writeFileSync(itemPath, source, "utf8");
+  console.log("Applied canonical A/B/C enchanting workshop patch.");
+} else {
+  console.log("Canonical A/B/C enchanting workshop patch already present.");
+}
+
+for (const token of ['from "../utils/enchanting"', "buildEnchantingPreview", "craft-enchant-slot-grid", "enchanting-catalyst-", "enchantingPreview", "replaces_base_item", "recipe.craft_disabled", "finalizeStepReady"]) {
+  if (!source.includes(token)) throw new Error(`Enchanting page validation failed: ${token}`);
+}
+
+const stylePath = path.join(process.cwd(), "styles", "globals.scss");
+let styles = fs.readFileSync(stylePath, "utf8");
+const styleMarker = "/* ===== Canonical A/B/C enchanting workshop v1 ===== */";
+if (!styles.includes(styleMarker)) {
+  styles += `
+
+${styleMarker}
+.craft-enchant-trait-section,
+.craft-enchanting-result-preview {
+  border-color: rgba(171, 112, 255, .45);
+  background: radial-gradient(circle at top right, rgba(143, 82, 255, .16), transparent 42%), linear-gradient(145deg, rgba(35, 23, 54, .94), rgba(18, 14, 28, .98));
+}
+.craft-enchant-option-field { display: grid; gap: .35rem; }
+.craft-enchant-option-field > span { color: rgba(255,255,255,.68); font-size: .76rem; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; }
+.craft-enchant-slot-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .65rem; }
+.craft-enchant-slot-card { min-height: 126px; padding: .75rem; border: 1px solid rgba(156, 113, 214, .28); border-radius: 12px; background: rgba(10, 8, 17, .56); }
+.craft-enchant-slot-card.locked { opacity: .54; border-style: dashed; }
+.craft-enchant-slot-card.unlocked { box-shadow: inset 0 0 24px rgba(117, 70, 194, .08); }
+.craft-enchant-slot-card.targeted { border-color: rgba(198, 147, 255, .84); box-shadow: inset 0 0 0 1px rgba(198, 147, 255, .22), 0 0 24px rgba(120, 70, 210, .14); }
+.craft-enchant-slot-card.replacing { border-color: rgba(244, 166, 94, .82); }
+.craft-enchant-slot-head { display: flex; align-items: center; justify-content: space-between; gap: .5rem; margin-bottom: .55rem; }
+.craft-enchant-slot-head strong { color: #e7d4ff; font-size: .9rem; }
+.craft-enchant-slot-head span { color: rgba(255,255,255,.58); font-size: .68rem; text-transform: uppercase; letter-spacing: .06em; }
+.craft-enchant-slot-name { color: #fff; font-weight: 750; line-height: 1.25; }
+.craft-enchant-slot-rarity,
+.craft-enchant-slot-empty,
+.craft-enchant-replace-note,
+.craft-base-pattern-card small { display: block; margin-top: .3rem; color: rgba(255,255,255,.62); font-size: .72rem; line-height: 1.35; }
+.craft-enchant-replace-note { margin-top: .55rem; color: #efbd88; }
+.craft-row-craft-button:disabled { cursor: not-allowed; opacity: .52; }
+@media (max-width: 760px) { .craft-enchant-slot-grid { grid-template-columns: 1fr; } }
+`;
+  fs.writeFileSync(stylePath, styles, "utf8");
+  console.log("Appended canonical enchanting workshop styles.");
+} else {
+  console.log("Canonical enchanting workshop styles already present.");
+}
+if (!styles.includes(".craft-enchant-slot-grid")) throw new Error("Enchanting style validation failed");

--- a/scripts/patch_professions_canonical_crafting.mjs
+++ b/scripts/patch_professions_canonical_crafting.mjs
@@ -4,6 +4,7 @@ const transformers = [
   new URL("disambiguate_crafting_target_state.mjs", import.meta.url),
   new URL("patch_self_crafting_professions.mjs", import.meta.url),
   new URL("patch_enchanting_workshop.mjs", import.meta.url),
+  new URL("patch_enchanting_catalog_consistency.mjs", import.meta.url),
 ];
 for (const transformer of transformers) {
   await import(transformer.href);

--- a/scripts/patch_professions_canonical_crafting.mjs
+++ b/scripts/patch_professions_canonical_crafting.mjs
@@ -1,8 +1,9 @@
-// Profession source transformer compatibility entry.
+// Profession and crafting source-transformer entry point.
 const transformers = [
   new URL("patch_professions_canonical_crafting_v2.mjs", import.meta.url),
   new URL("disambiguate_crafting_target_state.mjs", import.meta.url),
   new URL("patch_self_crafting_professions.mjs", import.meta.url),
+  new URL("patch_enchanting_workshop.mjs", import.meta.url),
 ];
 for (const transformer of transformers) {
   await import(transformer.href);

--- a/scripts/patch_professions_canonical_crafting.mjs
+++ b/scripts/patch_professions_canonical_crafting.mjs
@@ -5,6 +5,7 @@ const transformers = [
   new URL("patch_self_crafting_professions.mjs", import.meta.url),
   new URL("patch_enchanting_workshop.mjs", import.meta.url),
   new URL("patch_enchanting_catalog_consistency.mjs", import.meta.url),
+  new URL("canonicalize_weapon_enchants.mjs", import.meta.url),
 ];
 for (const transformer of transformers) {
   await import(transformer.href);

--- a/scripts/test_enchanting_model.mjs
+++ b/scripts/test_enchanting_model.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import {
+  buildEnchantingPreview,
+  enchantingRequirementCheck,
+  enchantingSlotForRarity,
+  isEnchantingCatalyst,
+  isEnchantingRecipeFuture,
+} from "../utils/enchanting.js";
+
+const commonCatalyst = { id: "c1", name: "Arcane Catalyst", category: "Catalyst", rarity: "Common", tags: ["arcane"] };
+const uncommonCatalyst = { id: "c2", name: "Sigil Dust", category: "Catalyst", rarity: "Uncommon", tags: ["sigil"] };
+const rareCatalyst = { id: "c3", name: "Planar Core", category: "Catalyst", rarity: "Rare", tags: ["core"] };
+
+assert.equal(enchantingSlotForRarity("Common"), "A");
+assert.equal(enchantingSlotForRarity("Uncommon"), "A");
+assert.equal(enchantingSlotForRarity("Rare"), "B");
+assert.equal(enchantingSlotForRarity("Very Rare"), "C");
+assert.equal(enchantingSlotForRarity("Legendary"), "");
+
+const rareWeaponRecipe = {
+  id: "enchant:wounding",
+  key: "wounding",
+  name: "Weapon of Wounding",
+  rarity: "Rare",
+  applies_to: ["weapon"],
+  variant: {
+    key: "wounding",
+    rarity: "rare",
+    appliesTo: ["weapon"],
+    requires: { weaponFamily: ["sword"] },
+    textByKind: { weapon: "On a hit, the target takes an extra 1d8 Necrotic damage." },
+  },
+};
+
+const plusOneSword = { name: "+1 Longsword", type: "M", rarity: "Uncommon", payload: { damageType: "S" } };
+const plusThreeSword = {
+  name: "+3 Longsword — Moon-Touched / Warning",
+  type: "M",
+  rarity: "Very Rare",
+  payload: {
+    damageType: "S",
+    enchanting: {
+      base_name: "+3 Longsword",
+      base_entries: ["Base weapon rule."],
+      slots: {
+        A: { slot: "A", key: "moon_touched", name: "Moon-Touched", rarity: "Common", effect_text: "Glows in darkness.", entries: ["Glows in darkness."] },
+        C: { slot: "C", key: "warning", name: "Weapon of Warning", rarity: "Very Rare", effect_text: "Warns its bearer.", entries: ["Warns its bearer."] },
+      },
+    },
+  },
+};
+
+assert.equal(enchantingRequirementCheck(plusOneSword, rareWeaponRecipe).ok, false, "Slot B must reject +1 gear");
+assert.equal(enchantingRequirementCheck(plusThreeSword, rareWeaponRecipe).ok, true, "legacy sword-only naming must remain broad Weapon compatibility");
+assert.equal(isEnchantingCatalyst(commonCatalyst, rareWeaponRecipe, "B"), false, "Slot B needs Uncommon or better catalyst");
+assert.equal(isEnchantingCatalyst(uncommonCatalyst, rareWeaponRecipe, "B"), true);
+assert.equal(isEnchantingCatalyst(rareCatalyst, rareWeaponRecipe, "C"), true);
+
+const preview = buildEnchantingPreview(rareWeaponRecipe, plusThreeSword, null, uncommonCatalyst);
+assert.equal(preview.valid, true);
+assert.equal(preview.slot, "B");
+assert.equal(preview.nextSlots.A.key, "moon_touched", "Slot A must be inherited");
+assert.equal(preview.nextSlots.C.key, "warning", "Slot C must be inherited");
+assert.equal(preview.nextSlots.B.key, "wounding", "Slot B must be replaced/created");
+assert.match(preview.finalName, /^\+3 Longsword — Moon-Touched \/ Wounding \/ Warning$/);
+assert.deepEqual(preview.baseEntries, ["Base weapon rule."]);
+
+const slashingRecipe = {
+  ...rareWeaponRecipe,
+  key: "sharpness",
+  name: "Weapon of Sharpness",
+  variant: { ...rareWeaponRecipe.variant, key: "sharpness", requires: { damageType: ["slashing"] } },
+};
+const mace = { name: "+3 Mace", type: "M", rarity: "Very Rare", payload: { damageType: "B" } };
+assert.equal(enchantingRequirementCheck(mace, slashingRecipe).ok, false, "real damage-type restrictions must remain enforced");
+
+assert.equal(isEnchantingRecipeFuture({ key: "vorpal", rarity: "Legendary" }), true);
+assert.equal(isEnchantingRecipeFuture({ key: "enspell_weapon", rarity: "Varies" }), true);
+
+console.log("Enchanting model tests passed.");

--- a/sql/20260617_01_enchanting_completion_v1.sql
+++ b/sql/20260617_01_enchanting_completion_v1.sql
@@ -1,0 +1,395 @@
+begin;
+
+create or replace function private.complete_enchanting_craft_plan_v1_impl(
+  p_plan_id uuid,
+  p_attempt_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private, auth
+as $function$
+declare
+  v_plan public.craft_plans%rowtype;
+  v_attempt public.crafting_attempts%rowtype;
+  v_base public.inventory_items%rowtype;
+  v_snapshot jsonb := '{}'::jsonb;
+  v_variant jsonb := '{}'::jsonb;
+  v_crafter jsonb := '{}'::jsonb;
+  v_existing_slots jsonb := '{}'::jsonb;
+  v_next_slots jsonb := '{}'::jsonb;
+  v_base_entries jsonb := '[]'::jsonb;
+  v_final_entries jsonb := '[]'::jsonb;
+  v_output_payload jsonb := '{}'::jsonb;
+  v_slot text;
+  v_expected_slot text;
+  v_variant_rarity text;
+  v_tier integer := 0;
+  v_base_name text;
+  v_output_name text;
+  v_output_rarity text;
+  v_output_description text;
+  v_output_id uuid;
+  v_target_kind text;
+  v_owner_type text;
+  v_owner_id text;
+  v_target_user_id uuid;
+  v_material jsonb;
+  v_material_id uuid;
+  v_required integer;
+  v_current_qty integer;
+  v_report text;
+  v_actor_id uuid;
+  v_actor_name text;
+begin
+  select * into v_plan
+  from public.craft_plans
+  where id = p_plan_id
+  for update;
+
+  if not found then
+    raise exception 'Craft plan % not found', p_plan_id;
+  end if;
+  if lower(coalesce(v_plan.discipline, '')) <> 'enchanting' then
+    raise exception 'Craft plan % is not an Enchanting plan', p_plan_id;
+  end if;
+  if v_plan.status = 'completed' then
+    raise exception 'Craft plan % is already completed', p_plan_id;
+  end if;
+
+  if p_attempt_id is not null then
+    select * into v_attempt
+    from public.crafting_attempts
+    where id = p_attempt_id and craft_plan_id = p_plan_id
+    order by created_at desc
+    limit 1;
+  else
+    select * into v_attempt
+    from public.crafting_attempts
+    where craft_plan_id = p_plan_id
+    order by created_at desc
+    limit 1;
+  end if;
+
+  if v_attempt.id is null then
+    raise exception 'No attempt report found for craft plan %', p_plan_id;
+  end if;
+  if coalesce(v_attempt.result_tier, '') not in ('critical_success', 'success') then
+    raise exception 'Craft plan % cannot complete from result tier %', p_plan_id, v_attempt.result_tier;
+  end if;
+  if v_plan.target_character_id is null then
+    raise exception 'Craft plan % has no target character', p_plan_id;
+  end if;
+  if v_plan.target_inventory_item_id is null then
+    raise exception 'Enchanting craft plan % has no base inventory item', p_plan_id;
+  end if;
+
+  v_snapshot := coalesce(
+    v_plan.result_item_payload->'enchanting',
+    v_plan.plan_payload->'enchanting',
+    v_plan.result_item_payload->'automation_preview'->'enchanting',
+    v_plan.plan_payload->'automation_preview'->'enchanting',
+    '{}'::jsonb
+  );
+  if v_snapshot = '{}'::jsonb then
+    raise exception 'Enchanting craft plan % has no canonical enchanting snapshot', p_plan_id;
+  end if;
+
+  v_slot := upper(coalesce(v_snapshot->>'slot', ''));
+  if v_slot not in ('A', 'B', 'C') then
+    raise exception 'Enchanting craft plan % has invalid target slot %', p_plan_id, v_slot;
+  end if;
+
+  v_variant := coalesce(v_snapshot->'variant', '{}'::jsonb);
+  if v_variant = '{}'::jsonb or nullif(v_variant->>'name', '') is null then
+    raise exception 'Enchanting craft plan % has no resolved variant', p_plan_id;
+  end if;
+
+  select * into v_base
+  from public.inventory_items
+  where id = v_plan.target_inventory_item_id
+  for update;
+
+  if not found then
+    raise exception 'Base inventory item % was not found', v_plan.target_inventory_item_id;
+  end if;
+  if coalesce(v_base.quantity, 0) < 1 then
+    raise exception 'Base inventory item % has no available quantity', v_base.id;
+  end if;
+
+  v_tier := coalesce(
+    nullif(v_base.card_payload->>'enhancement_tier', '')::integer,
+    nullif(v_base.card_payload->>'enhancementTier', '')::integer,
+    nullif(v_base.card_payload->>'magic_tier', '')::integer,
+    nullif(v_base.card_payload->>'magicTier', '')::integer,
+    nullif(v_base.card_payload->>'tier', '')::integer,
+    nullif(substring(v_base.item_name from '\\+([1-3])'), '')::integer,
+    nullif(v_snapshot->>'tier', '')::integer,
+    0
+  );
+
+  if v_tier < 1 or v_tier > 3 then
+    raise exception 'Base item % does not have a supported +1 to +3 smith tier', v_base.item_name;
+  end if;
+  if (v_slot = 'B' and v_tier < 2) or (v_slot = 'C' and v_tier < 3) then
+    raise exception 'Slot % is not unlocked on +% item %', v_slot, v_tier, v_base.item_name;
+  end if;
+
+  v_variant_rarity := lower(coalesce(
+    v_variant->>'rarity',
+    v_plan.result_item_payload->'recipe'->>'rarity',
+    v_plan.plan_payload->'recipe'->>'rarity',
+    v_plan.rarity,
+    ''
+  ));
+  v_expected_slot := case
+    when v_variant_rarity in ('common', 'uncommon') then 'A'
+    when v_variant_rarity = 'rare' then 'B'
+    when v_variant_rarity in ('very rare', 'very_rare') then 'C'
+    else null
+  end;
+  if v_expected_slot is null then
+    raise exception 'Rarity % is outside the current A/B/C enchanting workshop', v_variant_rarity;
+  end if;
+  if v_expected_slot <> v_slot then
+    raise exception 'Variant rarity % belongs in Slot %, not Slot %', v_variant_rarity, v_expected_slot, v_slot;
+  end if;
+
+  if lower(concat_ws(' ', v_base.item_type, v_base.card_payload->>'item_type', v_base.card_payload->>'type', v_base.card_payload->>'uiType'))
+     !~ 'weapon|armor|armour|shield|ammunition|melee|ranged|(^|[^a-z])(m|r|a|la|ma|ha|s|sh)([^a-z]|$)' then
+    raise exception 'Base item % is not a supported physical gear type', v_base.item_name;
+  end if;
+
+  v_existing_slots := coalesce(v_base.card_payload#>'{enchanting,slots}', '{}'::jsonb);
+  if v_existing_slots = '{}'::jsonb then
+    v_existing_slots := coalesce(v_snapshot->'existingSlots', v_snapshot->'existing_slots', '{}'::jsonb);
+  end if;
+  v_variant := v_variant || jsonb_build_object('slot', v_slot, 'applied_at', now());
+  v_next_slots := jsonb_set(v_existing_slots, array[v_slot], v_variant, true);
+  v_base_name := coalesce(
+    nullif(v_base.card_payload#>>'{enchanting,base_name}', ''),
+    nullif(v_snapshot->>'baseName', ''),
+    nullif(v_snapshot->>'base_name', ''),
+    v_base.item_name
+  );
+  v_base_entries := coalesce(
+    v_base.card_payload#>'{enchanting,base_entries}',
+    v_snapshot->'baseEntries',
+    v_snapshot->'base_entries',
+    '[]'::jsonb
+  );
+  if jsonb_typeof(v_base_entries) <> 'array' then
+    v_base_entries := '[]'::jsonb;
+  end if;
+
+  with ordered_lines as (
+    select nullif(value #>> '{}', '') as line, 100 + ordinality::integer as sort_key
+    from jsonb_array_elements(v_base_entries) with ordinality
+    union all
+    select nullif(slot_value->>'effect_text', ''),
+           case slot_key when 'A' then 1000 when 'B' then 2000 when 'C' then 3000 else 4000 end
+    from jsonb_each(v_next_slots) as slots(slot_key, slot_value)
+    union all
+    select nullif(entry_value #>> '{}', ''),
+           (case slot_key when 'A' then 1100 when 'B' then 2100 when 'C' then 3100 else 4100 end) + ordinality::integer
+    from jsonb_each(v_next_slots) as slots(slot_key, slot_value)
+    cross join lateral jsonb_array_elements(
+      case when jsonb_typeof(slot_value->'entries') = 'array' then slot_value->'entries' else '[]'::jsonb end
+    ) with ordinality as entries(entry_value, ordinality)
+  ), deduped as (
+    select line, min(sort_key) as sort_key
+    from ordered_lines
+    where line is not null
+    group by line
+  )
+  select coalesce(jsonb_agg(to_jsonb(line) order by sort_key), '[]'::jsonb)
+  into v_final_entries
+  from deduped;
+
+  select string_agg(value #>> '{}', E'\n')
+  into v_output_description
+  from jsonb_array_elements(v_final_entries);
+
+  v_output_name := coalesce(nullif(v_snapshot->>'finalName', ''), nullif(v_snapshot->>'final_name', ''), v_plan.result_item_name, v_base.item_name);
+  v_output_rarity := coalesce(
+    nullif(v_snapshot->>'outputRarity', ''),
+    nullif(v_snapshot->>'output_rarity', ''),
+    nullif(v_base.item_rarity, ''),
+    case v_tier when 1 then 'Uncommon' when 2 then 'Rare' when 3 then 'Very Rare' end
+  );
+
+  select coalesce(kind, 'npc') into v_target_kind
+  from public.characters
+  where id = v_plan.target_character_id;
+  if found then
+    v_owner_type := case when v_target_kind = 'merchant' then 'merchant' else 'npc' end;
+    v_owner_id := v_plan.target_character_id::text;
+    v_target_user_id := null;
+  else
+    select user_id into v_target_user_id
+    from public.players
+    where id = v_plan.target_character_id;
+    if not found or v_target_user_id is null then
+      raise exception 'Craft target % was not found or has no user_id', v_plan.target_character_id;
+    end if;
+    v_owner_type := 'player';
+    v_owner_id := v_target_user_id::text;
+  end if;
+
+  for v_material in
+    select value from jsonb_array_elements(coalesce(v_plan.selected_materials, '[]'::jsonb))
+  loop
+    if nullif(v_material->>'inventory_item_id', '') is null then
+      continue;
+    end if;
+    v_material_id := (v_material->>'inventory_item_id')::uuid;
+    if v_material_id = v_base.id then
+      raise exception 'The base item cannot also be consumed as an enchanting catalyst';
+    end if;
+    v_required := greatest(coalesce(nullif(v_material->>'quantity_required', '')::integer, 1), 1);
+    select quantity into v_current_qty
+    from public.inventory_items
+    where id = v_material_id
+    for update;
+    if not found then
+      raise exception 'Selected catalyst item % was not found', v_material_id;
+    end if;
+    if coalesce(v_current_qty, 0) < v_required then
+      raise exception 'Selected catalyst item % has quantity %, requires %', v_material_id, v_current_qty, v_required;
+    end if;
+    if v_current_qty = v_required then
+      delete from public.inventory_items where id = v_material_id;
+    else
+      update public.inventory_items
+      set quantity = v_current_qty - v_required, updated_at = now()
+      where id = v_material_id;
+    end if;
+  end loop;
+
+  if v_base.quantity = 1 then
+    delete from public.inventory_items where id = v_base.id;
+  else
+    update public.inventory_items
+    set quantity = v_base.quantity - 1, updated_at = now()
+    where id = v_base.id;
+  end if;
+
+  v_crafter := coalesce(v_plan.result_item_payload->'crafter_snapshot', v_plan.plan_payload->'crafter_snapshot', '{}'::jsonb);
+  v_actor_id := nullif(v_crafter->>'character_id', '')::uuid;
+  v_actor_name := coalesce(nullif(v_crafter->>'character_name', ''), v_plan.target_character_name, 'A crafter');
+  v_report := concat_ws(' ', v_actor_name, 'replaced Slot', v_slot, 'on', v_base.item_name || ',', 'creating', v_output_name || '.', 'Attempt:', v_attempt.result_tier || ',', 'roll', coalesce(v_attempt.roll_total::text, '—'), 'vs DC', coalesce(v_attempt.dc::text, '—') || '.');
+
+  v_output_payload := coalesce(v_base.card_payload, '{}'::jsonb)
+    || jsonb_build_object(
+      'name', v_output_name,
+      'item_name', v_output_name,
+      'rarity', v_output_rarity,
+      'item_rarity', v_output_rarity,
+      'entries', v_final_entries,
+      'item_description', v_output_description,
+      'effect_text', v_output_description,
+      'rulesText', v_output_description,
+      'enchanting', jsonb_build_object(
+        'version', 1,
+        'base_name', v_base_name,
+        'tier', v_tier,
+        'slots', v_next_slots,
+        'base_entries', v_base_entries,
+        'last_replaced_slot', v_slot,
+        'source_base_inventory_item_id', v_base.id,
+        'updated_at', now()
+      ),
+      'crafting', coalesce(v_base.card_payload->'crafting', '{}'::jsonb) || jsonb_build_object(
+        'craft_plan_id', v_plan.id,
+        'attempt_id', v_attempt.id,
+        'recipe_id', v_plan.recipe_id,
+        'recipe_name', v_plan.recipe_name,
+        'selected_materials', coalesce(v_plan.selected_materials, '[]'::jsonb),
+        'crafter_snapshot', v_crafter,
+        'completion_report', v_report,
+        'attempt_result', v_attempt.result_tier,
+        'attempt_roll_total', v_attempt.roll_total,
+        'attempt_dc', v_attempt.dc,
+        'replaced_inventory_item_id', v_base.id,
+        'replaced_slot', v_slot
+      )
+    );
+
+  insert into public.inventory_items (
+    item_id, owner_type, owner_id, user_id, item_name, item_type, item_rarity,
+    item_description, item_weight, item_cost, quantity, card_payload, is_equipped,
+    created_at, updated_at
+  ) values (
+    v_base.item_id, v_owner_type, v_owner_id, v_target_user_id, v_output_name,
+    v_base.item_type, v_output_rarity, v_output_description, v_base.item_weight,
+    v_base.item_cost, 1, v_output_payload, v_base.is_equipped, now(), now()
+  ) returning id into v_output_id;
+
+  update public.craft_plans
+  set status = 'completed', completed_at = now(), completed_attempt_id = v_attempt.id,
+      completion_output_item_id = v_output_id, completion_report = v_report, updated_at = now()
+  where id = v_plan.id;
+
+  insert into public.crafting_attempts (
+    craft_plan_id, actor_character_id, actor_character_name, recipe_id, recipe_name,
+    roll_total, dc, result_tier, selected_materials, material_effects,
+    consumed_materials, output_item_payload, report_text
+  ) values (
+    v_plan.id, v_actor_id, v_actor_name, v_plan.recipe_id, v_plan.recipe_name,
+    v_attempt.roll_total, v_attempt.dc, 'completed', coalesce(v_plan.selected_materials, '[]'::jsonb),
+    coalesce(v_attempt.material_effects, '[]'::jsonb), coalesce(v_plan.selected_materials, '[]'::jsonb),
+    jsonb_build_object('created_inventory_item_id', v_output_id, 'replaced_inventory_item_id', v_base.id, 'name', v_output_name, 'card_payload', v_output_payload),
+    v_report
+  );
+
+  return jsonb_build_object(
+    'ok', true,
+    'craft_plan_id', v_plan.id,
+    'attempt_id', v_attempt.id,
+    'created_item_id', v_output_id,
+    'created_item_name', v_output_name,
+    'replaced_item_id', v_base.id,
+    'replaced_slot', v_slot,
+    'owner_type', v_owner_type,
+    'owner_id', v_owner_id,
+    'slots', v_next_slots,
+    'report', v_report
+  );
+end;
+$function$;
+
+create or replace function public.complete_craft_plan_v1(
+  p_plan_id uuid,
+  p_attempt_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private, auth
+as $function$
+declare
+  caller_role text := coalesce(auth.role(), '');
+  v_discipline text;
+begin
+  if caller_role <> 'service_role' and not private.current_user_is_admin() then
+    raise exception 'Only an administrator can complete a craft plan' using errcode = '42501';
+  end if;
+
+  select lower(coalesce(discipline, '')) into v_discipline
+  from public.craft_plans
+  where id = p_plan_id;
+
+  if v_discipline is null then
+    raise exception 'Craft plan % not found', p_plan_id;
+  end if;
+  if v_discipline = 'enchanting' then
+    return private.complete_enchanting_craft_plan_v1_impl(p_plan_id, p_attempt_id);
+  end if;
+  return private.complete_craft_plan_v1_impl(p_plan_id, p_attempt_id);
+end;
+$function$;
+
+comment on function private.complete_enchanting_craft_plan_v1_impl(uuid, uuid) is
+  'Completes a successful Enchanting craft atomically: consumes one base item and its catalyst, replaces only the targeted A/B/C slot, preserves other slots, and creates one replacement inventory item.';
+
+commit;

--- a/utils/enchanting.js
+++ b/utils/enchanting.js
@@ -1,0 +1,463 @@
+export const ENCHANTING_SLOT_ORDER = Object.freeze(["A", "B", "C"]);
+
+export const ENCHANTING_SLOT_RULES = Object.freeze({
+  A: Object.freeze({ key: "A", label: "Slot A", minimumTier: 1, minimumCatalystRarity: "Common", allowedRarities: Object.freeze(["Common", "Uncommon"]) }),
+  B: Object.freeze({ key: "B", label: "Slot B", minimumTier: 2, minimumCatalystRarity: "Uncommon", allowedRarities: Object.freeze(["Rare"]) }),
+  C: Object.freeze({ key: "C", label: "Slot C", minimumTier: 3, minimumCatalystRarity: "Rare", allowedRarities: Object.freeze(["Very Rare"]) }),
+});
+
+const RARITY_ORDER = Object.freeze(["Mundane", "Common", "Uncommon", "Rare", "Very Rare", "Legendary", "Artifact"]);
+const RARITY_RANK = Object.freeze(Object.fromEntries(RARITY_ORDER.map((value, index) => [value, index])));
+const TIER_RARITY = Object.freeze({ 1: "Uncommon", 2: "Rare", 3: "Very Rare" });
+const PHYSICAL_TYPE_CODES = Object.freeze({ M: "weapon", R: "weapon", A: "ammunition", LA: "armor", MA: "armor", HA: "armor", S: "shield", SH: "shield" });
+const DAMAGE_TYPE_CODES = Object.freeze({ B: "bludgeoning", P: "piercing", S: "slashing", A: "acid", C: "cold", F: "fire", L: "lightning", N: "necrotic", R: "radiant", T: "thunder", FRC: "force", PSY: "psychic", PSN: "poison" });
+
+function text(value = "") {
+  return String(value ?? "").trim();
+}
+
+function normalizedToken(value = "") {
+  return text(value).toLowerCase().replace(/[’']/g, "").replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
+function arrayValue(value) {
+  if (Array.isArray(value)) return value.filter((entry) => entry !== null && entry !== undefined && entry !== "");
+  if (value === null || value === undefined || value === "") return [];
+  return [value];
+}
+
+function objectValue(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function dedupe(values = []) {
+  const seen = new Set();
+  return values.filter((value) => {
+    const key = text(typeof value === "string" ? value : JSON.stringify(value));
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function normalizeEnchantingRarity(value = "") {
+  const token = normalizedToken(value);
+  if (!token || token === "none" || token === "mundane") return "Mundane";
+  if (token.includes("artifact")) return "Artifact";
+  if (token.includes("legend")) return "Legendary";
+  if (token.includes("very rare")) return "Very Rare";
+  if (token.includes("uncommon")) return "Uncommon";
+  if (token.includes("rare")) return "Rare";
+  if (token.includes("common")) return "Common";
+  if (token.includes("varies") || token.includes("variable")) return "Varies";
+  return text(value);
+}
+
+export function enchantingRarityRank(value = "") {
+  return RARITY_RANK[normalizeEnchantingRarity(value)] ?? -1;
+}
+
+export function enchantingSlotForRarity(value = "") {
+  const rarity = normalizeEnchantingRarity(value);
+  if (rarity === "Common" || rarity === "Uncommon") return "A";
+  if (rarity === "Rare") return "B";
+  if (rarity === "Very Rare") return "C";
+  return "";
+}
+
+export function enchantingSlotForRecipe(recipe = {}, option = null) {
+  return enchantingSlotForRarity(resolveEnchantingRecipeRarity(recipe, option));
+}
+
+export function enchantingTierForItem(item = {}) {
+  const payload = objectValue(item.payload || item.card_payload || item.raw?.card_payload);
+  const raw = objectValue(item.raw);
+  const explicit = Number(
+    payload.enhancement_tier ?? payload.enhancementTier ?? payload.magic_tier ?? payload.magicTier ?? payload.tier
+    ?? raw.enhancement_tier ?? raw.enhancementTier ?? raw.magic_tier ?? raw.magicTier ?? raw.tier ?? 0
+  );
+  if (explicit >= 1 && explicit <= 3) return explicit;
+  const nameBlob = [item.name, item.item_name, raw.item_name, payload.name, payload.item_name].filter(Boolean).join(" ");
+  const match = nameBlob.match(/(?:^|\s)\+([1-3])\b/);
+  return match ? Number(match[1]) : 0;
+}
+
+export function enchantingUnlockedSlots(tier = 0) {
+  const value = Math.max(0, Math.min(3, Number(tier) || 0));
+  return ENCHANTING_SLOT_ORDER.filter((slot) => ENCHANTING_SLOT_RULES[slot].minimumTier <= value);
+}
+
+export function enchantingItemPayload(item = {}) {
+  return objectValue(item.payload || item.card_payload || item.raw?.card_payload);
+}
+
+function typeCode(value = "") {
+  return text(value).split("|")[0].trim().toUpperCase();
+}
+
+export function enchantingItemKind(item = {}) {
+  const payload = enchantingItemPayload(item);
+  const raw = objectValue(item.raw);
+  const candidates = [item.type, item.item_type, payload.item_type, payload.type, payload.uiType, raw.item_type, raw.type].filter(Boolean);
+  for (const candidate of candidates) {
+    const code = typeCode(candidate);
+    if (PHYSICAL_TYPE_CODES[code]) return PHYSICAL_TYPE_CODES[code];
+  }
+  const blob = [item.name, item.item_name, ...candidates].filter(Boolean).join(" ").toLowerCase();
+  if (/\bammunition\b|\bammo\b|\barrow\b|\bbolt\b/.test(blob)) return "ammunition";
+  if (/\bshield\b/.test(blob)) return "shield";
+  if (/\barmor\b|\barmour\b|\bmail\b|\bplate\b|\bbreastplate\b|\bleather\b/.test(blob)) return "armor";
+  if (/\bweapon\b|\bsword\b|\baxe\b|\bmace\b|\bhammer\b|\bbow\b|\bcrossbow\b|\bspear\b|\bdagger\b|\bstaff\b|\bwhip\b|\brapier\b|\bscimitar\b|\bsickle\b|\btrident\b|\bflail\b|\blance\b|\bsling\b/.test(blob)) return "weapon";
+  return "";
+}
+
+export function enchantingWeaponMode(item = {}) {
+  if (enchantingItemKind(item) !== "weapon") return "";
+  const payload = enchantingItemPayload(item);
+  const raw = objectValue(item.raw);
+  const code = typeCode(item.type || item.item_type || payload.item_type || payload.type || raw.item_type || raw.type);
+  if (code === "R") return "ranged";
+  if (code === "M") return "melee";
+  const blob = [item.name, item.item_name, item.type, payload.item_type, payload.type, payload.uiType].filter(Boolean).join(" ").toLowerCase();
+  return /\bbow\b|\bcrossbow\b|\bsling\b|\bblowgun\b|\branged\b/.test(blob) ? "ranged" : "melee";
+}
+
+export function enchantingWeaponFamily(item = {}) {
+  const payload = enchantingItemPayload(item);
+  const raw = objectValue(item.raw);
+  const explicit = text(payload.weapon_family || payload.weaponFamily || raw.weapon_family || raw.weaponFamily);
+  if (explicit) return normalizedToken(explicit);
+  const name = normalizedToken(item.name || item.item_name || raw.item_name || payload.name || payload.item_name);
+  const families = [
+    "longsword", "shortsword", "greatsword", "scimitar", "rapier", "dagger", "sickle", "spear", "trident", "lance", "whip",
+    "battleaxe", "greataxe", "handaxe", "warhammer", "maul", "mace", "club", "flail", "quarterstaff", "staff",
+    "longbow", "shortbow", "crossbow", "sling", "blowgun",
+  ];
+  return families.find((family) => name.includes(family)) || (name.includes("sword") ? "sword" : name.includes("axe") ? "axe" : name.includes("bow") ? "bow" : "");
+}
+
+export function enchantingDamageTypes(item = {}) {
+  const payload = enchantingItemPayload(item);
+  const raw = objectValue(item.raw);
+  const values = [payload.damage_type, payload.damageType, payload.dmgType, raw.damage_type, raw.damageType, raw.dmgType, item.damage_type, item.damageType]
+    .flatMap(arrayValue)
+    .map((value) => DAMAGE_TYPE_CODES[text(value).toUpperCase()] || normalizedToken(value))
+    .filter(Boolean);
+  const blob = [payload.damage, payload.damage_text, payload.item_description, raw.item_description, item.description].filter(Boolean).join(" ").toLowerCase();
+  ["bludgeoning", "piercing", "slashing", "acid", "cold", "fire", "force", "lightning", "necrotic", "poison", "psychic", "radiant", "thunder"].forEach((damageType) => {
+    if (blob.includes(damageType)) values.push(damageType);
+  });
+  return dedupe(values);
+}
+
+export function resolveEnchantingRecipeRarity(recipe = {}, option = null) {
+  const raw = objectValue(recipe.variant || recipe.raw_variant || recipe.rawVariant);
+  const rarityByValue = objectValue(raw.rarityByValue || recipe.rarity_by_value || recipe.rarityByValue);
+  const key = option === null || option === undefined ? "" : String(option);
+  return normalizeEnchantingRarity(rarityByValue[key] || recipe.rarity || raw.rarity || (Object.keys(rarityByValue).length ? "Varies" : ""));
+}
+
+export function isEnchantingRecipeFuture(recipe = {}, option = null) {
+  const key = normalizedToken(recipe.key || recipe.variant?.key || recipe.name).replace(/\s+/g, "_");
+  const recipeRarity = resolveEnchantingRecipeRarity(recipe, option);
+  if (recipeRarity === "Legendary" || recipeRarity === "Artifact") return true;
+  if (key === "enspell_weapon" || key === "enspell_armor") return true;
+  return Boolean(recipe.craft_disabled || recipe.future);
+}
+
+export function enchantingRecipeDisabledReason(recipe = {}, option = null) {
+  if (recipe.disabled_reason) return text(recipe.disabled_reason);
+  const key = normalizedToken(recipe.key || recipe.variant?.key || recipe.name).replace(/\s+/g, "_");
+  if (key === "enspell_weapon" || key === "enspell_armor") return "Spell-bound enchantments remain unavailable until the campaign spell catalog is imported.";
+  const recipeRarity = resolveEnchantingRecipeRarity(recipe, option);
+  if (recipeRarity === "Legendary" || recipeRarity === "Artifact") return "Legendary enchanting is reserved for a later tier beyond the current A/B/C workshop.";
+  return "This enchantment is not currently available for crafting.";
+}
+
+function recipeVariant(recipe = {}) {
+  return objectValue(recipe.variant || recipe.raw_variant || recipe.rawVariant);
+}
+
+function recipeAppliesTo(recipe = {}) {
+  const raw = recipeVariant(recipe);
+  return dedupe(arrayValue(recipe.applies_to || recipe.appliesTo || raw.appliesTo).map((value) => normalizedToken(value).replace(/\s+/g, "")));
+}
+
+function recipeRequires(recipe = {}) {
+  const raw = recipeVariant(recipe);
+  const value = recipe.requires || raw.requires;
+  if (Array.isArray(value)) return value.reduce((merged, entry) => ({ ...merged, ...objectValue(entry) }), {});
+  return objectValue(value);
+}
+
+export function enchantingRequirementCheck(item = {}, recipe = {}, option = null) {
+  const kind = enchantingItemKind(item);
+  const tier = enchantingTierForItem(item);
+  const recipeRarity = resolveEnchantingRecipeRarity(recipe, option);
+  const slot = enchantingSlotForRarity(recipeRarity);
+  const minimumTier = slot ? ENCHANTING_SLOT_RULES[slot].minimumTier : 99;
+  if (!kind || !["weapon", "armor", "shield", "ammunition"].includes(kind)) {
+    return { ok: false, reason: "Only weapons, armor, shields, and ammunition can be enchanted.", kind, tier, slot, rarity: recipeRarity };
+  }
+  if (!slot || isEnchantingRecipeFuture(recipe, option)) {
+    return { ok: false, reason: enchantingRecipeDisabledReason(recipe, option), kind, tier, slot, rarity: recipeRarity };
+  }
+  if (tier < minimumTier || tier > 3) {
+    return { ok: false, reason: `${ENCHANTING_SLOT_RULES[slot].label} requires a +${minimumTier} or higher smith-tiered item.`, kind, tier, slot, rarity: recipeRarity };
+  }
+  const appliesTo = recipeAppliesTo(recipe);
+  if (appliesTo.length && !appliesTo.includes(kind)) {
+    return { ok: false, reason: `This enchantment applies to ${appliesTo.join(", ")}, not ${kind}.`, kind, tier, slot, rarity: recipeRarity };
+  }
+  const requires = recipeRequires(recipe);
+  const allowedFamilies = arrayValue(requires.weaponFamily || requires.weapon_family).map(normalizedToken);
+  const family = enchantingWeaponFamily(item);
+  const effectiveFamilies = allowedFamilies.length === 1 && allowedFamilies[0] === "sword" ? [] : allowedFamilies;
+  if (kind === "weapon" && effectiveFamilies.length && !effectiveFamilies.some((allowed) => family === allowed || family.includes(allowed) || allowed.includes(family))) {
+    return { ok: false, reason: `This pattern requires one of: ${effectiveFamilies.join(", ")}.`, kind, tier, slot, rarity: recipeRarity, family };
+  }
+  const requiredDamage = arrayValue(requires.damageType || requires.damage_type).map(normalizedToken);
+  const damageTypes = enchantingDamageTypes(item);
+  if (requiredDamage.length && !requiredDamage.some((allowed) => damageTypes.includes(allowed))) {
+    return { ok: false, reason: `This pattern requires ${requiredDamage.join(" or ")} damage.`, kind, tier, slot, rarity: recipeRarity, family, damageTypes };
+  }
+  return { ok: true, reason: "Compatible", kind, tier, slot, rarity: recipeRarity, family, damageTypes };
+}
+
+function normalizeSlotEntry(value, slot = "") {
+  const entry = objectValue(value);
+  if (!Object.keys(entry).length) return null;
+  return {
+    slot: slot || text(entry.slot).toUpperCase(),
+    key: text(entry.key || entry.id || entry.name),
+    name: text(entry.name || entry.label || entry.title || "Unnamed Enchantment"),
+    rarity: normalizeEnchantingRarity(entry.rarity || ""),
+    source: text(entry.source || "Enchanting"),
+    option: entry.option ?? entry.selected_option ?? null,
+    effect_text: text(entry.effect_text || entry.effect || entry.text || entry.description),
+    entries: dedupe(arrayValue(entry.entries).map((line) => text(line)).filter(Boolean)),
+    catalyst: entry.catalyst && typeof entry.catalyst === "object" ? entry.catalyst : null,
+    applied_at: entry.applied_at || entry.appliedAt || null,
+  };
+}
+
+export function normalizeEnchantingSlots(item = {}) {
+  const payload = enchantingItemPayload(item);
+  const enchanting = objectValue(payload.enchanting);
+  const slotsSource = objectValue(enchanting.slots || payload.enchantment_slots || payload.enchanting_slots || payload.magic_slots);
+  const result = {};
+  ENCHANTING_SLOT_ORDER.forEach((slot) => {
+    const normalized = normalizeSlotEntry(slotsSource[slot] || slotsSource[slot.toLowerCase()], slot);
+    if (normalized) result[slot] = normalized;
+  });
+  arrayValue(payload.enchantments || enchanting.enchantments).forEach((entry, index) => {
+    const slot = text(entry?.slot).toUpperCase() || ENCHANTING_SLOT_ORDER[index];
+    if (!ENCHANTING_SLOT_ORDER.includes(slot) || result[slot]) return;
+    const normalized = normalizeSlotEntry(entry, slot);
+    if (normalized) result[slot] = normalized;
+  });
+  return result;
+}
+
+export function enchantingBaseName(item = {}) {
+  const payload = enchantingItemPayload(item);
+  const stored = text(payload.enchanting?.base_name || payload.enchanting?.baseName || payload.crafting?.base_name);
+  if (stored) return stored;
+  const current = text(item.name || item.item_name || item.raw?.item_name || payload.name || payload.item_name || "Unnamed Item");
+  const slots = normalizeEnchantingSlots(item);
+  let cleaned = current;
+  Object.values(slots).forEach((entry) => {
+    if (!entry?.name) return;
+    const escaped = entry.name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    cleaned = cleaned.replace(new RegExp(`\\s*(?:—|–|-|/|\\|)\\s*${escaped}`, "ig"), "");
+  });
+  return cleaned.replace(/\s+(?:—|–|-|\/|\|)\s*$/, "").replace(/\s+/g, " ").trim() || current;
+}
+
+function shortEnchantName(value = "") {
+  return text(value).replace(/^Sword of\s+/i, "").replace(/^Weapon of\s+/i, "").replace(/^Armor of\s+/i, "").replace(/^Shield of\s+/i, "").replace(/^Ammunition of\s+/i, "").replace(/^\+\d+\s*/i, "").trim();
+}
+
+export function composeEnchantingResultName(baseName = "", slots = {}) {
+  const base = text(baseName || "Enchanted Item");
+  const names = ENCHANTING_SLOT_ORDER.map((slot) => shortEnchantName(slots?.[slot]?.name)).filter(Boolean);
+  return names.length ? `${base} — ${names.join(" / ")}` : base;
+}
+
+function flattenTextEntries(value) {
+  const result = [];
+  const visit = (node) => {
+    if (!node) return;
+    if (typeof node === "string") {
+      const cleaned = text(node);
+      if (cleaned) result.push(cleaned);
+      return;
+    }
+    if (Array.isArray(node)) return node.forEach(visit);
+    if (typeof node === "object") {
+      if (node.entry) visit(node.entry);
+      if (node.entries) visit(node.entries);
+      if (node.items) visit(node.items);
+    }
+  };
+  visit(value);
+  return dedupe(result);
+}
+
+function itemBaseEntries(item = {}) {
+  const payload = enchantingItemPayload(item);
+  const stored = arrayValue(payload.enchanting?.base_entries || payload.enchanting?.baseEntries);
+  if (stored.length) return flattenTextEntries(stored);
+  const existingEnchantEntries = new Set(Object.values(normalizeEnchantingSlots(item)).flatMap((entry) => [entry.effect_text, ...(entry.entries || [])]).map(text).filter(Boolean));
+  return flattenTextEntries(payload.entries || item.entries || item.raw?.entries || payload.item_description || item.raw?.item_description)
+    .filter((entry) => !existingEnchantEntries.has(text(entry)));
+}
+
+function substituteVariantTokens(value = "", context = {}) {
+  return text(value)
+    .replaceAll("{OPTION}", text(context.option).toUpperCase())
+    .replaceAll("{LEVEL}", text(context.option))
+    .replaceAll("{N}", text(context.option))
+    .replaceAll("{DC}", text(context.dc))
+    .replaceAll("{ATK}", text(context.attackBonus))
+    .replaceAll("{SCHOOLS}", text(context.schools));
+}
+
+export function enchantingVariantEffect(recipe = {}, item = {}, option = null) {
+  const raw = recipeVariant(recipe);
+  const kind = enchantingItemKind(item);
+  const textByKind = objectValue(raw.textByKind || recipe.text_by_kind || recipe.textByKind);
+  const dcByValue = objectValue(raw.dcByValue || recipe.dc_by_value || recipe.dcByValue);
+  const attackByValue = objectValue(raw.attackBonusByValue || recipe.attack_bonus_by_value || recipe.attackBonusByValue);
+  const context = { option, dc: dcByValue[String(option)] ?? "", attackBonus: attackByValue[String(option)] ?? "", schools: raw.schools || recipe.schools || "" };
+  const primary = textByKind[kind] || textByKind.weapon || textByKind.armor || textByKind.shield || textByKind.ammunition || recipe.effect_text || recipe.summary;
+  return substituteVariantTokens(primary, context);
+}
+
+export function enchantingVariantEntries(recipe = {}, item = {}, option = null) {
+  const raw = recipeVariant(recipe);
+  const effect = enchantingVariantEffect(recipe, item, option);
+  const rawEntries = flattenTextEntries(raw.entries || recipe.entries).map((entry) => substituteVariantTokens(entry, { option, schools: raw.schools || recipe.schools || "" }));
+  return dedupe([effect, ...rawEntries].filter(Boolean));
+}
+
+export function enchantingRecipeOptions(recipe = {}) {
+  const raw = recipeVariant(recipe);
+  return arrayValue(raw.options || recipe.options);
+}
+
+export function enchantingRecipeAffinityTags(recipe = {}, option = null) {
+  const raw = recipeVariant(recipe);
+  const blob = [recipe.name, recipe.summary, enchantingVariantEffect(recipe, {}, option), option, ...arrayValue(raw.options)].filter(Boolean).join(" ").toLowerCase();
+  const tags = [];
+  ["acid", "cold", "fire", "force", "lightning", "necrotic", "poison", "psychic", "radiant", "thunder", "bludgeoning", "piercing", "slashing"].forEach((tag) => {
+    if (blob.includes(tag)) tags.push(tag);
+  });
+  if (/holy|divine|sun|radiant/.test(blob)) tags.push("holy", "radiant");
+  if (/mind|psychic|dream|thought/.test(blob)) tags.push("mind", "psychic");
+  if (/shadow|necrotic|death|wound|life stealing/.test(blob)) tags.push("shadow", "necrotic");
+  if (/storm|lightning|thunder|wind|zephyr/.test(blob)) tags.push("storm");
+  if (/fey|sylvan|nature|beast/.test(blob)) tags.push("fey", "nature");
+  if (/ward|resistance|anchoring|defen/.test(blob)) tags.push("ward");
+  return dedupe(tags);
+}
+
+function materialBlob(material = {}) {
+  const payload = objectValue(material.payload || material.raw?.payload || material.raw?.card_payload);
+  return [material.name, material.item_name, material.category, material.type, material.rarity, material.notes, material.description, ...arrayValue(material.tags), ...arrayValue(material.raw?.tags), ...arrayValue(payload.tags)].filter(Boolean).join(" ").toLowerCase();
+}
+
+export function isEnchantingCatalyst(material = {}, recipe = {}, slot = "", option = null) {
+  if (!material) return false;
+  const targetSlot = slot || enchantingSlotForRecipe(recipe, option);
+  const rule = ENCHANTING_SLOT_RULES[targetSlot];
+  if (!rule) return false;
+  const blob = materialBlob(material);
+  if (!/catalyst|essence|core|shard|gem|crystal|dust|resin|rune|sigil|quintessence|aether|arcane/.test(blob)) return false;
+  return enchantingRarityRank(material.rarity || "Common") >= enchantingRarityRank(rule.minimumCatalystRarity);
+}
+
+export function enchantingCatalystEffect(material = {}, recipe = {}, slot = "", option = null) {
+  if (!material) return null;
+  const targetSlot = slot || enchantingSlotForRecipe(recipe, option);
+  const affinities = enchantingRecipeAffinityTags(recipe, option);
+  const blob = materialBlob(material);
+  const matchedAffinities = affinities.filter((tag) => blob.includes(tag));
+  return {
+    name: matchedAffinities.length ? "Resonant Arcane Catalyst" : "Arcane Binding Catalyst",
+    dc_modifier: 0,
+    effect_summary: matchedAffinities.length
+      ? `Stabilizes Slot ${targetSlot} and resonates with ${matchedAffinities.join(", ")}.`
+      : `Stabilizes the Slot ${targetSlot} binding without changing the Craft DC.`,
+    risk_summary: "The catalyst is consumed when the successful enchantment replaces the selected slot.",
+    affinity_tags: matchedAffinities,
+    applicable_label: "Binding impact",
+  };
+}
+
+function catalystSnapshot(catalyst = null) {
+  if (!catalyst) return null;
+  return {
+    inventory_item_id: catalyst.existing_work || catalyst.is_admin_virtual ? null : catalyst.id || null,
+    name: catalyst.name || catalyst.item_name || "Arcane Catalyst",
+    rarity: normalizeEnchantingRarity(catalyst.rarity || "Common"),
+    source: catalyst.source || "Inventory",
+    tags: dedupe(arrayValue(catalyst.tags)),
+    is_admin_virtual: Boolean(catalyst.is_admin_virtual),
+  };
+}
+
+export function buildEnchantingPreview(recipe = {}, item = null, option = null, catalyst = null) {
+  if (!recipe || !item) return null;
+  const check = enchantingRequirementCheck(item, recipe, option);
+  const slot = check.slot;
+  const existingSlots = normalizeEnchantingSlots(item);
+  const effectText = enchantingVariantEffect(recipe, item, option);
+  const variantEntries = enchantingVariantEntries(recipe, item, option);
+  const variant = slot ? {
+    slot,
+    key: text(recipe.key || recipe.variant?.key || recipe.id || recipe.name),
+    name: text(recipe.name || recipe.originalName || "Unnamed Enchantment"),
+    rarity: check.rarity,
+    source: text(recipe.source || recipe.variant?.source || "Enchanting"),
+    option: option === "" ? null : option,
+    effect_text: effectText,
+    entries: variantEntries,
+    catalyst: catalystSnapshot(catalyst),
+  } : null;
+  const nextSlots = { ...existingSlots };
+  if (slot && variant) nextSlots[slot] = variant;
+  const baseName = enchantingBaseName(item);
+  const baseEntries = itemBaseEntries(item);
+  const finalEntries = dedupe([
+    ...baseEntries,
+    ...ENCHANTING_SLOT_ORDER.flatMap((slotKey) => {
+      const entry = nextSlots[slotKey];
+      return entry ? [entry.effect_text, ...(entry.entries || [])] : [];
+    }),
+  ].filter(Boolean));
+  const tier = enchantingTierForItem(item);
+  const baseRarity = normalizeEnchantingRarity(item.rarity || item.item_rarity || enchantingItemPayload(item).rarity || TIER_RARITY[tier]);
+  const outputRarity = enchantingRarityRank(baseRarity) >= enchantingRarityRank(check.rarity) ? baseRarity : check.rarity;
+  return {
+    valid: check.ok && Boolean(catalyst),
+    requirement: check,
+    slot,
+    slotLabel: slot ? ENCHANTING_SLOT_RULES[slot].label : "Unavailable",
+    tier,
+    unlockedSlots: enchantingUnlockedSlots(tier),
+    baseName,
+    baseEntries,
+    existingSlots,
+    replacedSlot: slot ? existingSlots[slot] || null : null,
+    nextSlots,
+    variant,
+    effectText,
+    finalEntries,
+    finalName: composeEnchantingResultName(baseName, nextSlots),
+    outputRarity,
+    catalyst: catalystSnapshot(catalyst),
+    catalystRequired: true,
+    disabledReason: check.ok ? (!catalyst ? `Choose a compatible catalyst for Slot ${slot}.` : "") : check.reason,
+  };
+}


### PR DESCRIPTION
## Summary
- Rebuilds Enchanting around the accepted A/B/C slot model.
- Slot A is available on +1 gear, Slot B on +2 gear, and Slot C on +3 gear.
- Re-imbuing replaces only the targeted slot and preserves the other recorded slots.
- Enforces weapon, armor, shield, ammunition, damage-type, and specific-family compatibility.
- Keeps legacy sword-named patterns broad as Weapon patterns while retaining genuine damage/family restrictions.
- Adds a required tier-appropriate arcane catalyst without adding an arbitrary DC penalty.
- Adds option selection, final item naming, inherited-slot preview, replacement warnings, and violet workshop presentation.
- Marks Legendary and spell-bound Enspelled recipes as future content until their later tier/spell catalog is ready.
- Adds an isolated Enchanting completion function that atomically consumes one base item and the catalyst, then creates one replacement item with canonical slot history.
- Leaves Smithing and Alchemy completion on the existing implementation.

## Data safety
- The migration dispatches only `discipline = Enchanting` plans to the new completion path.
- The base inventory row is locked and consumed/decremented in the same transaction as catalyst consumption and output creation.
- The server independently verifies base tier, target slot, and variant rarity.
- Existing slots are preserved; only A, B, or C is replaced.
- No world-map files or behavior are changed.

## Validation
- Transformer syntax and idempotence.
- Production Next.js build.
- Generated-source stability after build.
- Migration safety-marker checks.
- Live Supabase syntax test will be performed in a rolled-back transaction before deployment.