### PR TITLE
Build canonical NPC Forge foundation

### DIFF
--- a/.github/workflows/validate-npc-forge.yml
+++ b/.github/workflows/validate-npc-forge.yml
@@ -11,6 +11,7 @@ on:
       - "styles/npc-forge.scss"
       - "utils/characterCreation.js"
       - "scripts/test_character_creation.mjs"
+      - "scripts/patch_character_creation_import.mjs"
       - "scripts/patch_npc_forge_page.mjs"
       - "scripts/patch_professions_canonical_crafting.mjs"
       - "sql/20260617_02_npc_forge_foundation_v1.sql"
@@ -41,8 +42,12 @@ jobs:
         run: |
           node --check utils/characterCreation.js
           node --check scripts/test_character_creation.mjs
+          node --check scripts/patch_character_creation_import.mjs
           node --check scripts/patch_npc_forge_page.mjs
           node --check scripts/patch_professions_canonical_crafting.mjs
+
+      - name: Normalize direct Node import
+        run: node scripts/patch_character_creation_import.mjs
 
       - name: Run character creation model tests
         shell: bash

--- a/.github/workflows/validate-npc-forge.yml
+++ b/.github/workflows/validate-npc-forge.yml
@@ -45,7 +45,20 @@ jobs:
           node --check scripts/patch_professions_canonical_crafting.mjs
 
       - name: Run character creation model tests
-        run: node scripts/test_character_creation.mjs
+        shell: bash
+        run: |
+          set +e
+          node scripts/test_character_creation.mjs > npc-forge-model-test.log 2>&1
+          status=$?
+          cat npc-forge-model-test.log
+          exit $status
+
+      - name: Upload model test diagnostic
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npc-forge-model-test
+          path: npc-forge-model-test.log
 
       - name: Validate migration safety markers
         run: |

--- a/.github/workflows/validate-npc-forge.yml
+++ b/.github/workflows/validate-npc-forge.yml
@@ -1,0 +1,85 @@
+name: Validate NPC Forge foundation
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "components/NewNpcModal.js"
+      - "pages/npcs.js"
+      - "pages/_app.js"
+      - "styles/npc-forge.scss"
+      - "utils/characterCreation.js"
+      - "scripts/test_character_creation.mjs"
+      - "scripts/patch_npc_forge_page.mjs"
+      - "scripts/patch_professions_canonical_crafting.mjs"
+      - "sql/20260617_02_npc_forge_foundation_v1.sql"
+      - ".github/workflows/validate-npc-forge.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate JavaScript syntax
+        run: |
+          node --check utils/characterCreation.js
+          node --check scripts/test_character_creation.mjs
+          node --check scripts/patch_npc_forge_page.mjs
+          node --check scripts/patch_professions_canonical_crafting.mjs
+
+      - name: Run character creation model tests
+        run: node scripts/test_character_creation.mjs
+
+      - name: Validate migration safety markers
+        run: |
+          grep -q "create_character_v1" sql/20260617_02_npc_forge_foundation_v1.sql
+          grep -q "delete_character_v1" sql/20260617_02_npc_forge_foundation_v1.sql
+          grep -q "protect_mog_delete_v1" sql/20260617_02_npc_forge_foundation_v1.sql
+          grep -q "owner_id = p_character_id::text" sql/20260617_02_npc_forge_foundation_v1.sql
+          grep -q "character_sheets" sql/20260617_02_npc_forge_foundation_v1.sql
+
+      - name: Apply source transformers once
+        run: npm run prebuild
+
+      - name: Validate generated NPC page integration
+        run: |
+          grep -q 'supabase.rpc("delete_character_v1"' pages/npcs.js
+          grep -q 'locations={locations}' pages/npcs.js
+          grep -q 'New Character' pages/npcs.js
+          ! grep -q 'setErrorMessage(' pages/npcs.js
+          ! grep -q 'selectedNpc' pages/npcs.js
+          ! grep -q 'setSelectedNpc' pages/npcs.js
+
+      - name: Stage first-pass generated sources
+        run: git add --all
+
+      - name: Verify second transformer pass is idempotent
+        run: |
+          npm run prebuild
+          git diff --exit-code
+
+      - name: Build production application
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: validation-placeholder
+        run: npm run build
+
+      - name: Verify build did not mutate generated sources
+        run: git diff --exit-code

--- a/components/NewNpcModal.js
+++ b/components/NewNpcModal.js
@@ -1,77 +1,191 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { supabase } from "../utils/supabaseClient";
+import { PROFESSION_DEFINITIONS, PROFESSION_KEYS } from "../utils/craftingProfessions";
+import {
+  ABILITY_KEYS,
+  ABILITY_LABELS,
+  BACKGROUND_DEFINITIONS,
+  BACKGROUND_KEYS,
+  CLASS_DEFINITIONS,
+  CLASS_KEYS,
+  FEAT_OPTIONS,
+  SKILL_DEFINITIONS,
+  SPECIES_DEFINITIONS,
+  SPECIES_KEYS,
+  applyBackgroundAbilityBoosts,
+  buildCharacterCreatePayload,
+  buildCharacterSheetFromDraft,
+  defaultBackgroundBoosts,
+  rollAbilitySet,
+  standardAbilityScores,
+  validateCharacterDraft,
+} from "../utils/characterCreation";
 
-// NPC creator foundation pass:
-// - Keeps the existing simple wizard intact.
-// - Adds explicit workshop roles so town crafting does not rely on fuzzy class/name inference.
-// - Stores crafter roles in characters.tags for TownSheet's Crafters' Quarter.
-const SPECIES_OPTIONS = [
-  { id: "human", name: "Human" },
-  { id: "dwarf", name: "Dwarf" },
-  { id: "elf", name: "Elf" },
-  { id: "halfling", name: "Halfling" },
-  { id: "gnome", name: "Gnome" },
-  { id: "dragonborn", name: "Dragonborn" },
-  { id: "tiefling", name: "Tiefling" },
-  { id: "halfOrc", name: "Half-Orc" },
-  { id: "halfElf", name: "Half-Elf" },
-  { id: "goliath", name: "Goliath" },
-];
+const STEP_LABELS = Object.freeze([
+  "Identity",
+  "Origin",
+  "Class",
+  "Abilities",
+  "Training",
+  "Story & Shop",
+  "Review",
+]);
 
-const CLASS_OPTIONS = [
-  { id: "barbarian", name: "Barbarian" },
-  { id: "bard", name: "Bard" },
-  { id: "cleric", name: "Cleric" },
-  { id: "druid", name: "Druid" },
-  { id: "fighter", name: "Fighter" },
-  { id: "monk", name: "Monk" },
-  { id: "paladin", name: "Paladin" },
-  { id: "ranger", name: "Ranger" },
-  { id: "rogue", name: "Rogue" },
-  { id: "sorcerer", name: "Sorcerer" },
-  { id: "warlock", name: "Warlock" },
-  { id: "wizard", name: "Wizard" },
-  { id: "commoner", name: "Commoner / Townsperson" },
-  { id: "expert", name: "Expert / Professional" },
-];
+const EMPTY_PROFESSIONS = Object.freeze(Object.fromEntries(PROFESSION_KEYS.map((key) => [key, {
+  rank: 0,
+  ability: PROFESSION_DEFINITIONS[key].abilities[0],
+  offersService: false,
+}])));
 
-const CRAFT_ROLE_OPTIONS = [
-  { id: "blacksmith", name: "Blacksmith", hint: "Forge mundane gear and reforge physical tier/+N upgrades." },
-  { id: "enchanter", name: "Enchanter", hint: "Add magical A/B/C enchant slots to already tiered gear." },
-  { id: "alchemist", name: "Alchemist", hint: "Future potion, poison, tonic, and reagent workflow." },
-  { id: "scribe", name: "Scribe", hint: "Future scroll, book, ritual, and inscription workflow." },
-  { id: "jeweler", name: "Jeweler", hint: "Future gem setting, focus stones, and socket work." },
-];
+function initialDraft() {
+  return {
+    name: "",
+    kind: "npc",
+    role: "",
+    affiliation: "",
+    speciesKey: "",
+    customSpecies: "",
+    lineage: "",
+    backgroundKey: "",
+    customBackground: "",
+    classKey: "civilian",
+    level: 1,
+    abilityMethod: "standard",
+    baseAbilities: standardAbilityScores("civilian"),
+    backgroundBoosts: defaultBackgroundBoosts("custom", "civilian"),
+    selectedClassSkills: [],
+    expertiseSkills: [],
+    professions: JSON.parse(JSON.stringify(EMPTY_PROFESSIONS)),
+    additionalFeats: [],
+    extraTraits: [],
+    preparedSpellsText: "",
+    attacks: "",
+    description: "",
+    backgroundNarrative: "",
+    motivation: "",
+    personalityTraits: "",
+    ideals: "",
+    bonds: "",
+    flaws: "",
+    quirk: "",
+    mannerism: "",
+    voice: "",
+    secret: "",
+    tags: [],
+    locationId: "",
+    storefrontEnabled: true,
+    storefrontTitle: "",
+    storefrontTagline: "",
+  };
+}
 
-const STEP_LABELS = ["Name", "Species", "Class", "Workshop", "Confirm"];
+function titleForSkill(key) {
+  return SKILL_DEFINITIONS.find((skill) => skill.key === key)?.label || key;
+}
 
-export default function NewNpcModal({ show, onClose, onCreated }) {
+function classSkillSelectionError(draft) {
+  const definition = CLASS_DEFINITIONS[draft.classKey] || CLASS_DEFINITIONS.civilian;
+  const selected = Array.from(new Set(draft.selectedClassSkills || []));
+  return selected.length === definition.skillCount
+    ? ""
+    : `Choose ${definition.skillCount} class skill${definition.skillCount === 1 ? "" : "s"}.`;
+}
+
+function stepErrors(step, draft) {
+  if (step === 0) {
+    const errors = [];
+    if (!String(draft.name || "").trim()) errors.push("Enter a name.");
+    if (!String(draft.role || "").trim()) errors.push("Enter a role or title so the roster remains useful.");
+    return errors;
+  }
+  if (step === 1) {
+    const errors = [];
+    if (!SPECIES_DEFINITIONS[draft.speciesKey]) errors.push("Choose a species.");
+    if (draft.speciesKey === "custom" && !String(draft.customSpecies || "").trim()) errors.push("Enter the custom species name.");
+    if (!BACKGROUND_DEFINITIONS[draft.backgroundKey]) errors.push("Choose a background.");
+    if (draft.backgroundKey === "custom" && !String(draft.customBackground || "").trim()) errors.push("Enter the custom background name.");
+    return errors;
+  }
+  if (step === 2) {
+    return CLASS_DEFINITIONS[draft.classKey] ? [] : ["Choose a class or No Adventuring Class."];
+  }
+  if (step === 3) {
+    const background = BACKGROUND_DEFINITIONS[draft.backgroundKey] || BACKGROUND_DEFINITIONS.custom;
+    const boosts = draft.backgroundBoosts || {};
+    if (boosts.mode === "three") {
+      const selected = Array.from(new Set(boosts.plusOnes || [])).filter((key) => background.abilities.includes(key));
+      return selected.length === 3 ? [] : ["Choose three different eligible +1 abilities."];
+    }
+    return background.abilities.includes(boosts.plusTwo)
+      && background.abilities.includes(boosts.plusOne)
+      && boosts.plusTwo !== boosts.plusOne
+      ? []
+      : ["Choose different eligible abilities for the +2 and +1 increases."];
+  }
+  if (step === 4) {
+    const errors = [];
+    const skillError = classSkillSelectionError(draft);
+    if (skillError) errors.push(skillError);
+    PROFESSION_KEYS.forEach((key) => {
+      const profession = draft.professions?.[key] || {};
+      if (profession.offersService && Number(profession.rank || 0) === 0) {
+        errors.push(`${PROFESSION_DEFINITIONS[key].label} must be trained before this NPC can offer it as a service.`);
+      }
+    });
+    return errors;
+  }
+  return [];
+}
+
+function ChoiceCard({ active, title, body, badge, onClick, disabled = false }) {
+  return (
+    <button
+      type="button"
+      className={`npc-forge-choice ${active ? "is-active" : ""}`}
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active ? "true" : "false"}
+    >
+      <span className="npc-forge-choice-head">
+        <strong>{title}</strong>
+        {badge ? <span className="npc-forge-choice-badge">{badge}</span> : null}
+      </span>
+      {body ? <span className="npc-forge-choice-body">{body}</span> : null}
+    </button>
+  );
+}
+
+export default function NewNpcModal({ show, onClose, onCreated, locations = [] }) {
   const [step, setStep] = useState(0);
-  const [name, setName] = useState("");
-  const [species, setSpecies] = useState("");
-  const [cls, setCls] = useState("");
-  const [craftRoles, setCraftRoles] = useState([]);
+  const [draft, setDraft] = useState(() => initialDraft());
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState("");
+  const [featToAdd, setFeatToAdd] = useState("");
+  const [tagInput, setTagInput] = useState("");
 
-  const canNext =
-    step === 0
-      ? name.trim().length > 0
-      : step === 1
-      ? !!species
-      : step === 2
-      ? !!cls
-      : step === 3
-      ? true
-      : false;
+  const classDefinition = CLASS_DEFINITIONS[draft.classKey] || CLASS_DEFINITIONS.civilian;
+  const backgroundDefinition = BACKGROUND_DEFINITIONS[draft.backgroundKey] || BACKGROUND_DEFINITIONS.custom;
+  const speciesDefinition = SPECIES_DEFINITIONS[draft.speciesKey] || null;
+  const sheetPreview = useMemo(() => buildCharacterSheetFromDraft(draft), [draft]);
+  const createPayload = useMemo(() => buildCharacterCreatePayload(draft), [draft]);
+  const finalAbilities = useMemo(
+    () => applyBackgroundAbilityBoosts(draft.baseAbilities, draft.backgroundKey, draft.backgroundBoosts),
+    [draft.baseAbilities, draft.backgroundKey, draft.backgroundBoosts]
+  );
+  const availableFeats = useMemo(() => FEAT_OPTIONS.filter((feat) => feat.minimumLevel <= Number(draft.level || 1)), [draft.level]);
+
+  function patch(patchValue) {
+    setDraft((current) => ({ ...current, ...patchValue }));
+    setError("");
+  }
 
   function resetForm() {
     setStep(0);
-    setName("");
-    setSpecies("");
-    setCls("");
-    setCraftRoles([]);
+    setDraft(initialDraft());
+    setCreating(false);
     setError("");
+    setFeatToAdd("");
+    setTagInput("");
   }
 
   function handleClose() {
@@ -80,220 +194,403 @@ export default function NewNpcModal({ show, onClose, onCreated }) {
     onClose?.();
   }
 
-  function toggleCraftRole(id) {
-    setCraftRoles((prev) => {
-      const set = new Set(prev || []);
-      if (set.has(id)) set.delete(id);
-      else set.add(id);
-      return Array.from(set);
+  function chooseClass(classKey) {
+    const backgroundKey = draft.backgroundKey || "custom";
+    patch({
+      classKey,
+      baseAbilities: standardAbilityScores(classKey),
+      abilityMethod: "standard",
+      selectedClassSkills: [],
+      expertiseSkills: [],
+      backgroundBoosts: defaultBackgroundBoosts(backgroundKey, classKey),
     });
+  }
+
+  function chooseBackground(backgroundKey) {
+    patch({
+      backgroundKey,
+      customBackground: backgroundKey === "custom" ? draft.customBackground : "",
+      backgroundBoosts: defaultBackgroundBoosts(backgroundKey, draft.classKey),
+    });
+  }
+
+  function setAbility(key, value) {
+    setDraft((current) => ({
+      ...current,
+      baseAbilities: {
+        ...(current.baseAbilities || {}),
+        [key]: Math.max(1, Math.min(30, Number(value) || 1)),
+      },
+    }));
+    setError("");
+  }
+
+  function setBackgroundBoost(field, value) {
+    setDraft((current) => ({
+      ...current,
+      backgroundBoosts: {
+        ...(current.backgroundBoosts || {}),
+        [field]: value,
+      },
+    }));
+    setError("");
+  }
+
+  function togglePlusOne(ability) {
+    setDraft((current) => {
+      const currentValues = Array.from(new Set(current.backgroundBoosts?.plusOnes || []));
+      const nextValues = currentValues.includes(ability)
+        ? currentValues.filter((value) => value !== ability)
+        : currentValues.length < 3
+          ? [...currentValues, ability]
+          : currentValues;
+      return {
+        ...current,
+        backgroundBoosts: { ...(current.backgroundBoosts || {}), mode: "three", plusOnes: nextValues },
+      };
+    });
+    setError("");
+  }
+
+  function toggleClassSkill(skillKey) {
+    setDraft((current) => {
+      const selected = Array.from(new Set(current.selectedClassSkills || []));
+      const next = selected.includes(skillKey)
+        ? selected.filter((value) => value !== skillKey)
+        : selected.length < classDefinition.skillCount
+          ? [...selected, skillKey]
+          : selected;
+      return { ...current, selectedClassSkills: next };
+    });
+    setError("");
+  }
+
+  function toggleExpertise(skillKey) {
+    setDraft((current) => {
+      const selected = new Set(current.expertiseSkills || []);
+      if (selected.has(skillKey)) selected.delete(skillKey);
+      else selected.add(skillKey);
+      return { ...current, expertiseSkills: Array.from(selected) };
+    });
+  }
+
+  function setProfession(professionKey, field, value) {
+    setDraft((current) => ({
+      ...current,
+      professions: {
+        ...(current.professions || {}),
+        [professionKey]: {
+          ...(current.professions?.[professionKey] || {}),
+          [field]: value,
+          ...(field === "rank" && Number(value) === 0 ? { offersService: false } : {}),
+        },
+      },
+    }));
+    setError("");
+  }
+
+  function addFeat() {
+    if (!featToAdd) return;
+    patch({ additionalFeats: Array.from(new Set([...(draft.additionalFeats || []), featToAdd])) });
+    setFeatToAdd("");
+  }
+
+  function addTag() {
+    const value = String(tagInput || "").trim().toLowerCase();
+    if (!value) return;
+    patch({ tags: Array.from(new Set([...(draft.tags || []), value])) });
+    setTagInput("");
+  }
+
+  function handleNext() {
+    const errors = stepErrors(step, draft);
+    if (errors.length) {
+      setError(errors.join(" "));
+      return;
+    }
+    setStep((current) => Math.min(STEP_LABELS.length - 1, current + 1));
+  }
+
+  function handleBack() {
+    setError("");
+    setStep((current) => Math.max(0, current - 1));
   }
 
   async function handleCreate() {
     if (creating) return;
+    const errors = validateCharacterDraft(draft);
+    if (errors.length) {
+      setError(errors.join(" "));
+      return;
+    }
+
     setCreating(true);
     setError("");
     try {
-      const now = new Date().toISOString();
-      const tags = Array.from(new Set((craftRoles || []).filter(Boolean)));
-
-      // Insert into characters. Default to is_hidden=true so the character starts off-map.
-      // Crafter roles live in `tags` so TownSheet can surface only clear workshop providers.
-      const { data: insertData, error: insertErr } = await supabase
-        .from("characters")
-        .insert({
-          name: name.trim(),
-          race: species || null,
-          // Save the class/profession label into role for now. Richer NPC sheet fields come later.
-          role: cls || null,
-          kind: "npc",
-          status: "alive",
-          is_hidden: true,
-          tags,
-          // NOTE: Do not set `created_at` because the `characters` table doesn't have this column.
-          updated_at: now,
-        })
-        .select("id")
-        .single();
-      if (insertErr || !insertData) throw insertErr || new Error("Insert failed");
-
-      const newId = insertData.id;
-      // Initialise an empty sheet for the new NPC.
-      await supabase
-        .from("character_sheets")
-        .insert({ character_id: newId, sheet: {}, updated_at: now });
-
+      const { data, error: rpcError } = await supabase.rpc("create_character_v1", {
+        p_payload: createPayload,
+      });
+      if (rpcError) throw rpcError;
+      const createdId = typeof data === "string" ? data : data?.id || data?.character_id || null;
+      const created = { id: createdId, kind: createPayload.kind, name: createPayload.name };
       resetForm();
-      if (typeof onCreated === "function") onCreated();
+      await onCreated?.(created);
     } catch (err) {
-      const msg = String(err?.message || err) || "Unknown error";
-      setError(msg);
-    } finally {
       setCreating(false);
+      setError(String(err?.message || err || "Failed to create character."));
     }
   }
 
-  function handleNext() {
-    if (!canNext) return;
-    setStep(step + 1);
-  }
-
-  function handleBack() {
-    setStep(Math.max(0, step - 1));
-  }
-
   if (!show) return null;
+
+  const originFeat = backgroundDefinition.feat || "None selected";
+  const selectedSkillKeys = Array.from(new Set([...(backgroundDefinition.skills || []), ...(draft.selectedClassSkills || [])]));
+  const selectedProfessionServices = PROFESSION_KEYS.filter((key) => draft.professions?.[key]?.offersService);
+
   return (
-    <div
-      className="position-fixed top-0 start-0 vw-100 vh-100 d-flex align-items-center justify-content-center"
-      style={{ background: "rgba(0,0,0,0.75)", zIndex: 1050 }}
-    >
-      <div
-        className="p-4 rounded-3"
-        style={{
-          background: "rgba(8, 10, 16, 0.95)",
-          border: "1px solid rgba(255,255,255,0.12)",
-          boxShadow: "0 10px 30px rgba(0,0,0,0.35)",
-          width: "90%",
-          maxWidth: "640px",
-          color: "white",
-        }}
-      >
-        <div className="d-flex justify-content-between align-items-start gap-3 mb-3">
+    <div className="npc-forge-backdrop" role="presentation">
+      <div className="npc-forge-modal" role="dialog" aria-modal="true" aria-labelledby="npc-forge-title">
+        <header className="npc-forge-header">
           <div>
-            <div className="text-uppercase text-white-50" style={{ fontSize: 11, letterSpacing: "0.12em" }}>
-              NPC creator
-            </div>
-            <h5 className="mb-1">Create New NPC</h5>
-            <div className="text-white-50" style={{ fontSize: 13 }}>
-              Step {step + 1} of {STEP_LABELS.length}: {STEP_LABELS[step]}
-            </div>
+            <div className="npc-forge-kicker">Canonical character system</div>
+            <h2 id="npc-forge-title">NPC Forge</h2>
+            <p>Create an NPC, merchant, or workshop provider with a complete sheet. New characters start off-map.</p>
           </div>
-          <button type="button" className="btn btn-sm btn-outline-light" onClick={handleClose} disabled={creating}>
-            Close
-          </button>
-        </div>
+          <button type="button" className="btn btn-sm btn-outline-light" onClick={handleClose} disabled={creating}>Close</button>
+        </header>
 
-        <div className="d-flex flex-wrap gap-2 mb-4">
-          {STEP_LABELS.map((label, idx) => (
-            <span
+        <nav className="npc-forge-steps" aria-label="NPC creation steps">
+          {STEP_LABELS.map((label, index) => (
+            <button
               key={label}
-              className={`badge ${idx === step ? "text-bg-primary" : idx < step ? "text-bg-success" : "text-bg-secondary"}`}
+              type="button"
+              className={`${index === step ? "is-current" : ""} ${index < step ? "is-complete" : ""}`}
+              onClick={() => { if (index <= step) { setStep(index); setError(""); } }}
+              disabled={creating || index > step}
             >
-              {label}
-            </span>
+              <span>{index + 1}</span>{label}
+            </button>
           ))}
-        </div>
+        </nav>
 
-        {step === 0 && (
-          <div>
-            <label className="form-label">Name</label>
-            <input
-              type="text"
-              className="form-control"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Enter NPC name"
-            />
-          </div>
-        )}
-
-        {step === 1 && (
-          <div>
-            <label className="form-label">Species</label>
-            <select className="form-select" value={species} onChange={(e) => setSpecies(e.target.value)}>
-              <option value="">Select species</option>
-              {SPECIES_OPTIONS.map((opt) => (
-                <option key={opt.id} value={opt.name}>{opt.name}</option>
-              ))}
-            </select>
-          </div>
-        )}
-
-        {step === 2 && (
-          <div>
-            <label className="form-label">Class / profession</label>
-            <select className="form-select" value={cls} onChange={(e) => setCls(e.target.value)}>
-              <option value="">Select class or profession</option>
-              {CLASS_OPTIONS.map((opt) => (
-                <option key={opt.id} value={opt.name}>{opt.name}</option>
-              ))}
-            </select>
-            <div className="form-text text-white-50">
-              This still saves to the existing <code>role</code> field. Workshop access is handled separately on the next step.
-            </div>
-          </div>
-        )}
-
-        {step === 3 && (
-          <div>
-            <div className="d-flex justify-content-between align-items-start gap-3 mb-2">
-              <div>
-                <label className="form-label mb-1">Workshop role</label>
-                <div className="text-white-50" style={{ fontSize: 13 }}>
-                  Optional. Pick one or more only if this NPC should appear in the Town Sheet Crafters' Quarter.
+        <div className="npc-forge-body">
+          <section className="npc-forge-workspace">
+            {step === 0 ? (
+              <div className="npc-forge-section">
+                <div className="npc-forge-section-heading">
+                  <div><span>Identity</span><h3>Who is this character?</h3></div>
+                  <p>Role is the in-world title. Class is chosen separately later.</p>
+                </div>
+                <div className="npc-forge-choice-grid two">
+                  <ChoiceCard active={draft.kind === "npc"} title="NPC" body="Resident, guard, ruler, quest giver, enemy, ally, or other character." onClick={() => patch({ kind: "npc", storefrontEnabled: false })} />
+                  <ChoiceCard active={draft.kind === "merchant"} title="Merchant" body="The same character model with optional storefront and stock capabilities." onClick={() => patch({ kind: "merchant", storefrontEnabled: true })} />
+                </div>
+                <div className="npc-forge-form-grid mt-3">
+                  <label className="wide"><span>Name *</span><input value={draft.name} onChange={(event) => patch({ name: event.target.value })} placeholder="Marta Ironroot" autoFocus /></label>
+                  <label><span>Role / title *</span><input value={draft.role} onChange={(event) => patch({ role: event.target.value })} placeholder="Master Armorer" /></label>
+                  <label><span>Affiliation</span><input value={draft.affiliation} onChange={(event) => patch({ affiliation: event.target.value })} placeholder="Gray Hall Smiths' Guild" /></label>
                 </div>
               </div>
-              {craftRoles.length ? (
-                <button type="button" className="btn btn-sm btn-outline-warning" onClick={() => setCraftRoles([])}>
-                  Clear
-                </button>
-              ) : null}
-            </div>
+            ) : null}
 
-            <div className="row g-2">
-              {CRAFT_ROLE_OPTIONS.map((role) => {
-                const active = craftRoles.includes(role.id);
-                return (
-                  <div key={role.id} className="col-12 col-md-6">
-                    <button
-                      type="button"
-                      className={`w-100 text-start p-3 rounded-3 ${active ? "border border-warning" : "border border-secondary"}`}
-                      style={{ background: active ? "rgba(245, 158, 11, 0.16)" : "rgba(255,255,255,0.04)", color: "white" }}
-                      onClick={() => toggleCraftRole(role.id)}
-                    >
-                      <div className="d-flex justify-content-between gap-2">
-                        <strong>{role.name}</strong>
-                        <span className={`badge ${active ? "text-bg-warning" : "text-bg-dark"}`}>{active ? "selected" : "off"}</span>
-                      </div>
-                      <div className="text-white-50 mt-1" style={{ fontSize: 12 }}>{role.hint}</div>
-                    </button>
+            {step === 1 ? (
+              <div className="npc-forge-section">
+                <div className="npc-forge-section-heading"><div><span>Origin</span><h3>Species and formative background</h3></div><p>Core 2024 options are available, with custom campaign species and backgrounds supported.</p></div>
+                <div className="npc-forge-subheading">Species</div>
+                <div className="npc-forge-choice-grid three">
+                  {SPECIES_KEYS.map((key) => {
+                    const option = SPECIES_DEFINITIONS[key];
+                    return <ChoiceCard key={key} active={draft.speciesKey === key} title={option.label} body={option.traits.slice(0, 3).join(" • ") || "Campaign-defined traits"} badge={`${option.speed} ft.`} onClick={() => patch({ speciesKey: key, lineage: "", customSpecies: key === "custom" ? draft.customSpecies : "" })} />;
+                  })}
+                </div>
+                {draft.speciesKey === "custom" ? <label className="npc-forge-inline-field mt-3"><span>Custom species name</span><input value={draft.customSpecies} onChange={(event) => patch({ customSpecies: event.target.value })} /></label> : null}
+                {speciesDefinition?.lineages?.length ? (
+                  <label className="npc-forge-inline-field mt-3"><span>Lineage / ancestry</span><select value={draft.lineage} onChange={(event) => patch({ lineage: event.target.value })}><option value="">Choose lineage</option>{speciesDefinition.lineages.map((lineage) => <option key={lineage} value={lineage}>{lineage}</option>)}</select></label>
+                ) : null}
+
+                <div className="npc-forge-subheading mt-4">Background</div>
+                <div className="npc-forge-choice-grid three">
+                  {BACKGROUND_KEYS.map((key) => {
+                    const option = BACKGROUND_DEFINITIONS[key];
+                    return <ChoiceCard key={key} active={draft.backgroundKey === key} title={option.label} body={option.skills.length ? `${option.skills.map(titleForSkill).join(" & ")} • ${option.tool}` : "Campaign-defined origin"} badge={option.feat || "Custom"} onClick={() => chooseBackground(key)} />;
+                  })}
+                </div>
+                {draft.backgroundKey === "custom" ? <label className="npc-forge-inline-field mt-3"><span>Custom background name</span><input value={draft.customBackground} onChange={(event) => patch({ customBackground: event.target.value })} /></label> : null}
+              </div>
+            ) : null}
+
+            {step === 2 ? (
+              <div className="npc-forge-section">
+                <div className="npc-forge-section-heading"><div><span>Class</span><h3>Adventuring training</h3></div><p>Class does not overwrite the in-world role or Profession skills.</p></div>
+                <div className="npc-forge-level-row">
+                  <label><span>Level</span><input type="number" min="1" max="20" value={draft.level} onChange={(event) => patch({ level: Math.max(1, Math.min(20, Number(event.target.value) || 1)) })} /></label>
+                  <div><span>Proficiency bonus</span><strong>+{sheetPreview.proficiencyBonus}</strong></div>
+                  <div><span>Hit Dice</span><strong>{sheetPreview.hitDice}</strong></div>
+                  <div><span>Expected HP</span><strong>{sheetPreview.maxHp}</strong></div>
+                </div>
+                <div className="npc-forge-choice-grid three mt-3">
+                  {CLASS_KEYS.map((key) => {
+                    const option = CLASS_DEFINITIONS[key];
+                    return <ChoiceCard key={key} active={draft.classKey === key} title={option.label} body={option.summary} badge={`d${option.hitDie}`} onClick={() => chooseClass(key)} />;
+                  })}
+                </div>
+                {classDefinition.spellcastingAbility ? <div className="npc-forge-callout mt-3"><strong>Spellcasting foundation</strong><span>{ABILITY_LABELS[classDefinition.spellcastingAbility]} is configured as the class spellcasting ability. Spell selection remains manual until the campaign spell catalog is imported.</span></div> : null}
+              </div>
+            ) : null}
+
+            {step === 3 ? (
+              <div className="npc-forge-section">
+                <div className="npc-forge-section-heading"><div><span>Abilities</span><h3>Generate and adjust ability scores</h3></div><p>Background increases are applied after the base scores and cannot raise a score above 20.</p></div>
+                <div className="npc-forge-segmented">
+                  <button type="button" className={draft.abilityMethod === "standard" ? "is-active" : ""} onClick={() => patch({ abilityMethod: "standard", baseAbilities: standardAbilityScores(draft.classKey) })}>Class Standard Array</button>
+                  <button type="button" className={draft.abilityMethod === "rolled" ? "is-active" : ""} onClick={() => patch({ abilityMethod: "rolled", baseAbilities: rollAbilitySet() })}>Roll 4d6 Drop Lowest</button>
+                  <button type="button" className={draft.abilityMethod === "manual" ? "is-active" : ""} onClick={() => patch({ abilityMethod: "manual" })}>Manual</button>
+                </div>
+                <div className="npc-forge-ability-grid mt-3">
+                  {ABILITY_KEYS.map((key) => (
+                    <label key={key}>
+                      <span>{ABILITY_LABELS[key]}</span>
+                      <input type="number" min="1" max="30" value={draft.baseAbilities?.[key] ?? 10} onChange={(event) => { patch({ abilityMethod: "manual" }); setAbility(key, event.target.value); }} />
+                      <small>Final {finalAbilities[key]}</small>
+                    </label>
+                  ))}
+                </div>
+                <div className="npc-forge-subheading mt-4">{backgroundDefinition.label} ability increases</div>
+                <div className="npc-forge-segmented compact">
+                  <button type="button" className={draft.backgroundBoosts?.mode !== "three" ? "is-active" : ""} onClick={() => setBackgroundBoost("mode", "twoOne")}>+2 and +1</button>
+                  <button type="button" className={draft.backgroundBoosts?.mode === "three" ? "is-active" : ""} onClick={() => setBackgroundBoost("mode", "three")}>Three +1s</button>
+                </div>
+                {draft.backgroundBoosts?.mode === "three" ? (
+                  <div className="npc-forge-choice-grid three mt-2">
+                    {backgroundDefinition.abilities.map((key) => <ChoiceCard key={key} active={(draft.backgroundBoosts?.plusOnes || []).includes(key)} title={ABILITY_LABELS[key]} badge="+1" onClick={() => togglePlusOne(key)} />)}
                   </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
+                ) : (
+                  <div className="npc-forge-form-grid mt-2">
+                    <label><span>Increase by 2</span><select value={draft.backgroundBoosts?.plusTwo || ""} onChange={(event) => setBackgroundBoost("plusTwo", event.target.value)}>{backgroundDefinition.abilities.map((key) => <option key={key} value={key}>{ABILITY_LABELS[key]}</option>)}</select></label>
+                    <label><span>Increase by 1</span><select value={draft.backgroundBoosts?.plusOne || ""} onChange={(event) => setBackgroundBoost("plusOne", event.target.value)}>{backgroundDefinition.abilities.map((key) => <option key={key} value={key}>{ABILITY_LABELS[key]}</option>)}</select></label>
+                  </div>
+                )}
+              </div>
+            ) : null}
 
-        {step === 4 && (
-          <div className="rounded-3 p-3" style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.12)" }}>
-            <p className="mb-2">Name: <strong>{name}</strong></p>
-            <p className="mb-2">Species: <strong>{species || "Unknown"}</strong></p>
-            <p className="mb-2">Class / profession: <strong>{cls || "Unknown"}</strong></p>
-            <p className="mb-0">
-              Workshop roles: <strong>{craftRoles.length ? craftRoles.map((id) => CRAFT_ROLE_OPTIONS.find((r) => r.id === id)?.name || id).join(", ") : "None"}</strong>
-            </p>
-          </div>
-        )}
+            {step === 4 ? (
+              <div className="npc-forge-section">
+                <div className="npc-forge-section-heading"><div><span>Training</span><h3>Skills and Professions</h3></div><p>Professions are real sheet checks. Workshop access is separate and explicit.</p></div>
+                <div className="npc-forge-subheading">Class skills <small>{(draft.selectedClassSkills || []).length}/{classDefinition.skillCount}</small></div>
+                <div className="npc-forge-skill-grid">
+                  {classDefinition.skillOptions.map((key) => {
+                    const selected = (draft.selectedClassSkills || []).includes(key);
+                    const backgroundGranted = backgroundDefinition.skills.includes(key);
+                    return (
+                      <button key={key} type="button" className={`${selected ? "is-active" : ""} ${backgroundGranted ? "is-background" : ""}`} onClick={() => toggleClassSkill(key)} disabled={backgroundGranted}>
+                        <span>{titleForSkill(key)}</span><small>{backgroundGranted ? "Background" : selected ? "Selected" : "Available"}</small>
+                      </button>
+                    );
+                  })}
+                </div>
+                <div className="npc-forge-subheading mt-4">Expertise <small>optional</small></div>
+                <div className="npc-forge-chip-row">
+                  {selectedSkillKeys.map((key) => <button key={key} type="button" className={(draft.expertiseSkills || []).includes(key) ? "is-active" : ""} onClick={() => toggleExpertise(key)}>{titleForSkill(key)}</button>)}
+                </div>
 
-        {error && <div className="alert alert-danger mt-3 py-2" style={{ fontSize: 14 }}>{error}</div>}
+                <div className="npc-forge-subheading mt-4">Professions</div>
+                <div className="npc-forge-profession-list">
+                  {PROFESSION_KEYS.map((key) => {
+                    const definition = PROFESSION_DEFINITIONS[key];
+                    const profession = draft.professions?.[key] || EMPTY_PROFESSIONS[key];
+                    return (
+                      <div key={key} className={`npc-forge-profession ${profession.offersService ? "is-provider" : ""}`}>
+                        <div><strong>{definition.label}</strong><small>{definition.tool}</small></div>
+                        <label><span>Rank</span><select value={profession.rank} onChange={(event) => setProfession(key, "rank", Number(event.target.value))}><option value={0}>Untrained</option><option value={1}>Proficient</option><option value={2}>Expertise</option></select></label>
+                        <label><span>Ability</span><select value={profession.ability} onChange={(event) => setProfession(key, "ability", event.target.value)}>{definition.abilities.map((ability) => <option key={ability} value={ability}>{ABILITY_LABELS[ability]}</option>)}</select></label>
+                        <label className="npc-forge-service-toggle"><input type="checkbox" checked={Boolean(profession.offersService)} disabled={Number(profession.rank || 0) === 0} onChange={(event) => setProfession(key, "offersService", event.target.checked)} /><span>Offers workshop service</span></label>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : null}
 
-        <div className="d-flex justify-content-between mt-4">
-          <button type="button" className="btn btn-secondary btn-sm" onClick={handleClose} disabled={creating}>Cancel</button>
-          <div>
-            {step > 0 && (
-              <button type="button" className="btn btn-outline-light btn-sm me-2" onClick={handleBack} disabled={creating}>Back</button>
-            )}
-            {step < STEP_LABELS.length - 1 && (
-              <button type="button" className="btn btn-primary btn-sm" onClick={handleNext} disabled={!canNext || creating}>Next</button>
-            )}
-            {step === STEP_LABELS.length - 1 && (
-              <button type="button" className="btn btn-success btn-sm" onClick={handleCreate} disabled={creating}>
-                {creating ? "Creating..." : "Create"}
-              </button>
-            )}
-          </div>
+            {step === 5 ? (
+              <div className="npc-forge-section">
+                <div className="npc-forge-section-heading"><div><span>Story & Shop</span><h3>Campaign hooks and placement</h3></div><p>These fields remain editable from the NPC page after creation.</p></div>
+                <div className="npc-forge-form-grid">
+                  <label className="wide"><span>Description</span><textarea rows={2} value={draft.description} onChange={(event) => patch({ description: event.target.value })} /></label>
+                  <label className="wide"><span>Background narrative</span><textarea rows={2} value={draft.backgroundNarrative} onChange={(event) => patch({ backgroundNarrative: event.target.value })} /></label>
+                  <label><span>Motivation / want</span><textarea rows={2} value={draft.motivation} onChange={(event) => patch({ motivation: event.target.value })} /></label>
+                  <label><span>Personality traits</span><textarea rows={2} value={draft.personalityTraits} onChange={(event) => patch({ personalityTraits: event.target.value })} /></label>
+                  <label><span>Ideals</span><textarea rows={2} value={draft.ideals} onChange={(event) => patch({ ideals: event.target.value })} /></label>
+                  <label><span>Bonds</span><textarea rows={2} value={draft.bonds} onChange={(event) => patch({ bonds: event.target.value })} /></label>
+                  <label><span>Flaws</span><textarea rows={2} value={draft.flaws} onChange={(event) => patch({ flaws: event.target.value })} /></label>
+                  <label><span>Quirk</span><textarea rows={2} value={draft.quirk} onChange={(event) => patch({ quirk: event.target.value })} /></label>
+                  <label><span>Mannerism</span><textarea rows={2} value={draft.mannerism} onChange={(event) => patch({ mannerism: event.target.value })} /></label>
+                  <label><span>Voice</span><textarea rows={2} value={draft.voice} onChange={(event) => patch({ voice: event.target.value })} /></label>
+                  <label className="wide"><span>Secret</span><textarea rows={2} value={draft.secret} onChange={(event) => patch({ secret: event.target.value })} /></label>
+                  <label className="wide"><span>Attacks & actions</span><textarea rows={3} value={draft.attacks} onChange={(event) => patch({ attacks: event.target.value })} placeholder="Add concise attacks, actions, reactions, or combat notes." /></label>
+                  {classDefinition.spellcastingAbility ? <label className="wide"><span>Prepared spells (manual placeholder)</span><textarea rows={3} value={draft.preparedSpellsText} onChange={(event) => patch({ preparedSpellsText: event.target.value })} placeholder="Spell catalog import will replace this free-text bridge." /></label> : null}
+                </div>
+
+                <div className="npc-forge-subheading mt-4">Additional feats</div>
+                <div className="npc-forge-add-row"><select value={featToAdd} onChange={(event) => setFeatToAdd(event.target.value)}><option value="">Choose feat</option>{availableFeats.map((feat) => <option key={`${feat.category}:${feat.name}`} value={feat.name}>{feat.name} ({feat.category})</option>)}</select><button type="button" onClick={addFeat} disabled={!featToAdd}>Add</button></div>
+                <div className="npc-forge-chip-row mt-2"><span className="is-fixed">{originFeat}</span>{(draft.additionalFeats || []).map((feat) => <button key={feat} type="button" onClick={() => patch({ additionalFeats: draft.additionalFeats.filter((value) => value !== feat) })}>{feat} ×</button>)}</div>
+
+                <div className="npc-forge-subheading mt-4">Roster tags</div>
+                <div className="npc-forge-add-row"><input value={tagInput} onChange={(event) => setTagInput(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") { event.preventDefault(); addTag(); } }} placeholder="guild, guard, ally, villain..." /><button type="button" onClick={addTag}>Add</button></div>
+                <div className="npc-forge-chip-row mt-2">{(draft.tags || []).map((tag) => <button key={tag} type="button" onClick={() => patch({ tags: draft.tags.filter((value) => value !== tag) })}>{tag} ×</button>)}</div>
+
+                <div className="npc-forge-subheading mt-4">Placement</div>
+                <div className="npc-forge-form-grid">
+                  <label><span>Starting location</span><select value={draft.locationId} onChange={(event) => patch({ locationId: event.target.value })}><option value="">Not listed</option>{(locations || []).map((location) => <option key={String(location.id)} value={String(location.id)}>{location.name}</option>)}</select></label>
+                  <div className="npc-forge-callout"><strong>Off-map by default</strong><span>The creator assigns identity and location only. It does not alter routes, movement, sprites, or world-map behavior.</span></div>
+                </div>
+
+                {draft.kind === "merchant" ? (
+                  <div className="npc-forge-merchant-box mt-4">
+                    <label className="npc-forge-service-toggle"><input type="checkbox" checked={Boolean(draft.storefrontEnabled)} onChange={(event) => patch({ storefrontEnabled: event.target.checked })} /><span>Enable storefront</span></label>
+                    {draft.storefrontEnabled ? <div className="npc-forge-form-grid mt-2"><label><span>Store title</span><input value={draft.storefrontTitle} onChange={(event) => patch({ storefrontTitle: event.target.value })} placeholder={`${draft.name || "Merchant"}'s Shop`} /></label><label><span>Store tagline</span><input value={draft.storefrontTagline} onChange={(event) => patch({ storefrontTagline: event.target.value })} placeholder="A concise shop description" /></label></div> : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
+            {step === 6 ? (
+              <div className="npc-forge-section">
+                <div className="npc-forge-section-heading"><div><span>Review</span><h3>Confirm the canonical character</h3></div><p>The character and sheet are created atomically. A partial NPC cannot be left behind.</p></div>
+                <div className="npc-forge-review-grid">
+                  <article><span>Identity</span><strong>{createPayload.name}</strong><p>{createPayload.race} • {createPayload.role}{createPayload.affiliation ? ` • ${createPayload.affiliation}` : ""}</p></article>
+                  <article><span>Origin</span><strong>{sheetPreview.background}</strong><p>{sheetPreview.lineage ? `${sheetPreview.species} (${sheetPreview.lineage})` : sheetPreview.species} • {originFeat}</p></article>
+                  <article><span>Class</span><strong>{sheetPreview.className} level {sheetPreview.level}</strong><p>PB +{sheetPreview.proficiencyBonus} • {sheetPreview.maxHp} HP • {sheetPreview.hitDice}</p></article>
+                  <article><span>Training</span><strong>{selectedSkillKeys.length} trained skills</strong><p>{selectedSkillKeys.map(titleForSkill).join(", ") || "None"}</p></article>
+                  <article><span>Workshops</span><strong>{selectedProfessionServices.length ? selectedProfessionServices.map((key) => PROFESSION_DEFINITIONS[key].label).join(", ") : "No services"}</strong><p>Only explicitly enabled services appear as workshop providers.</p></article>
+                  <article><span>Placement</span><strong>{(locations || []).find((location) => String(location.id) === String(draft.locationId))?.name || "Not listed"}</strong><p>Created off-map. {draft.kind === "merchant" && draft.storefrontEnabled ? "Storefront enabled." : "No storefront."}</p></article>
+                </div>
+                <div className="npc-forge-final-abilities mt-3">{ABILITY_KEYS.map((key) => <div key={key}><span>{key.toUpperCase()}</span><strong>{finalAbilities[key]}</strong><small>{Math.floor((finalAbilities[key] - 10) / 2) >= 0 ? "+" : ""}{Math.floor((finalAbilities[key] - 10) / 2)}</small></div>)}</div>
+                <details className="npc-forge-json mt-3"><summary>Review generated sheet JSON</summary><pre>{JSON.stringify(sheetPreview, null, 2)}</pre></details>
+              </div>
+            ) : null}
+          </section>
+
+          <aside className="npc-forge-preview">
+            <div className="npc-forge-preview-label">Live sheet summary</div>
+            <h3>{draft.name || "Unnamed Character"}</h3>
+            <p>{createPayload.race || "Species"} • {draft.role || "Role"}</p>
+            <div className="npc-forge-preview-stats"><div><span>Level</span><strong>{sheetPreview.level}</strong></div><div><span>PB</span><strong>+{sheetPreview.proficiencyBonus}</strong></div><div><span>AC</span><strong>{sheetPreview.ac || "—"}</strong></div><div><span>HP</span><strong>{sheetPreview.maxHp}</strong></div></div>
+            <div className="npc-forge-preview-abilities">{ABILITY_KEYS.map((key) => <div key={key}><span>{key.toUpperCase()}</span><strong>{finalAbilities[key]}</strong></div>)}</div>
+            <div className="npc-forge-preview-block"><span>Class</span><strong>{sheetPreview.className}</strong><small>{classDefinition.summary}</small></div>
+            <div className="npc-forge-preview-block"><span>Background</span><strong>{sheetPreview.background}</strong><small>{originFeat}</small></div>
+            <div className="npc-forge-preview-block"><span>Professions</span>{PROFESSION_KEYS.map((key) => { const profession = draft.professions?.[key]; return Number(profession?.rank || 0) > 0 ? <small key={key}>{PROFESSION_DEFINITIONS[key].label}: {Number(profession.rank) === 2 ? "Expertise" : "Proficient"} ({String(profession.ability || "").toUpperCase()}){profession.offersService ? " • Provider" : ""}</small> : null; })}</div>
+          </aside>
         </div>
+
+        {error ? <div className="npc-forge-error" role="alert">{error}</div> : null}
+
+        <footer className="npc-forge-footer">
+          <button type="button" className="btn btn-outline-light" onClick={handleClose} disabled={creating}>Cancel</button>
+          <div>
+            {step > 0 ? <button type="button" className="btn btn-outline-light" onClick={handleBack} disabled={creating}>Back</button> : null}
+            {step < STEP_LABELS.length - 1 ? <button type="button" className="btn btn-primary" onClick={handleNext} disabled={creating}>Continue</button> : <button type="button" className="btn btn-success" onClick={handleCreate} disabled={creating}>{creating ? "Forging Character..." : `Create ${draft.kind === "merchant" ? "Merchant" : "NPC"}`}</button>}
+          </div>
+        </footer>
       </div>
     </div>
   );

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 // pages/_app.js
 import "../styles/globals.scss";
+import "../styles/npc-forge.scss";
 import "../styles/card-compact.css";
 import AppNavbar from "../components/AppNavbar";
 import Head from "next/head";

--- a/scripts/patch_character_creation_import.mjs
+++ b/scripts/patch_character_creation_import.mjs
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const target = path.join(process.cwd(), "utils", "characterCreation.js");
+let source = fs.readFileSync(target, "utf8");
+const before = 'from "./craftingProfessions";';
+const after = 'from "./craftingProfessions.js";';
+
+if (source.includes(before)) {
+  source = source.replace(before, after);
+  fs.writeFileSync(target, source, "utf8");
+  console.log("Normalized the character creation model import for direct Node execution.");
+} else if (source.includes(after)) {
+  console.log("Character creation model import is already normalized.");
+} else {
+  throw new Error("Character creation model profession import was not found.");
+}

--- a/scripts/patch_npc_forge_page.mjs
+++ b/scripts/patch_npc_forge_page.mjs
@@ -74,7 +74,7 @@ if (!source.includes(marker)) {
     }
 
     if (typeof window !== "undefined") {
-      const ok = window.confirm(`Delete ${name}? Personal inventory, stock, notes, permissions, and sheet data will also be removed. This cannot be undone.`);
+      const ok = window.confirm("Delete " + name + "? Personal inventory, stock, notes, permissions, and sheet data will also be removed. This cannot be undone.");
       if (!ok) return;
     }
 

--- a/scripts/patch_npc_forge_page.mjs
+++ b/scripts/patch_npc_forge_page.mjs
@@ -1,0 +1,168 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const target = path.join(process.cwd(), "pages", "npcs.js");
+let source = fs.readFileSync(target, "utf8");
+const marker = "delete_character_v1";
+
+function replaceOnce(before, after, label) {
+  const count = source.split(before).length - 1;
+  if (count !== 1) throw new Error(`${label}: expected one match, found ${count}`);
+  source = source.replace(before, after);
+}
+
+if (!source.includes(marker)) {
+  replaceOnce(
+`  // Reload NPC list when a new NPC has been created via the builder
+  async function handleNewNpcCreated() {
+    await loadNpcs();
+    setShowNewNpcModal(false);
+  }
+
+  // Delete a character and dependent rows (schema has no ON DELETE CASCADE)
+  async function handleDeleteNpc(characterId) {
+    if (!characterId) return;
+
+    const npc = npcs.find((n) => String(n.id) === String(characterId));
+    const name = (npc && npc.name) ? npc.name : "this character";
+
+    if (typeof window !== "undefined") {
+      const ok = window.confirm("Delete " + name + "? This cannot be undone.");
+      if (!ok) return;
+    }
+
+    try {
+      setErrorMessage("");
+      // Delete dependents first
+      await supabase.from("character_notes").delete().eq("character_id", characterId);
+      await supabase.from("character_permissions").delete().eq("character_id", characterId);
+      await supabase.from("character_stock").delete().eq("character_id", characterId);
+      await supabase.from("character_sheets").delete().eq("character_id", characterId);
+      await supabase.from("inventory_items").delete().eq("character_id", characterId);
+
+      const { error } = await supabase.from("characters").delete().eq("id", characterId);
+      if (error) throw error;
+
+      setNpcs((prev) => prev.filter((c) => String(c.id) !== String(characterId)));
+      if (selectedNpc && String(selectedNpc.id) === String(characterId)) {
+        setSelectedNpc(null);
+      }
+    } catch (err) {
+      console.error("Delete NPC error", err);
+      setErrorMessage(err && err.message ? err.message : "Failed to delete character");
+    }
+  }`,
+`  // Reload the unified character roster after the NPC Forge creates a character.
+  async function handleNewNpcCreated(created) {
+    await Promise.all([loadNpcs(), loadMerchants(), loadMerchantProfiles()]);
+    setShowNewNpcModal(false);
+    if (created?.id) {
+      setSelectedKey(keyOf(created.kind === "merchant" ? "merchant" : "npc", created.id));
+    }
+  }
+
+  // Use the canonical server-side delete path. It cleans owner-model inventory,
+  // relies on database cascades for character dependents, and protects Mog.
+  async function handleDeleteNpc(characterId) {
+    if (!characterId || !isAdmin) return;
+
+    const entity = roster.find((entry) => String(entry.id) === String(characterId)) || selected;
+    const name = entity?.name || "this character";
+    if (String(name).trim().toLowerCase() === "mog") {
+      setErr("Mog is protected and cannot be deleted.");
+      return;
+    }
+
+    if (typeof window !== "undefined") {
+      const ok = window.confirm(`Delete ${name}? Personal inventory, stock, notes, permissions, and sheet data will also be removed. This cannot be undone.`);
+      if (!ok) return;
+    }
+
+    setErr("");
+    const { error } = await supabase.rpc("delete_character_v1", { p_character_id: characterId });
+    if (error) {
+      console.error("Delete character error", error);
+      setErr(error.message || "Failed to delete character.");
+      return;
+    }
+
+    setSelectedKey(null);
+    await Promise.all([loadNpcs(), loadMerchants(), loadMerchantProfiles()]);
+  }`,
+    "Canonical create/delete handlers"
+  );
+
+  replaceOnce(
+`  if (!roster.length) {
+    return (
+      <div className="container-fluid my-3 npcs-page">
+        <div style={{ color: MUTED }}>No NPCs or merchants found.</div>
+      </div>
+    );
+  }
+`,
+`  // Keep the page shell available when the roster is empty so an administrator
+  // can create the first canonical character from the NPC Forge.
+`,
+    "Empty-roster creator access"
+  );
+
+  replaceOnce(
+`                  title="Create new NPC"
+                >
+                  New NPC`,
+`                  title="Create a canonical NPC or merchant"
+                >
+                  New Character`,
+    "Creator button label"
+  );
+
+  replaceOnce(
+`            <div className="list-group flex-grow-1 overflow-auto npc-roster-list">
+              {roster.map((r) => {`,
+`            <div className="list-group flex-grow-1 overflow-auto npc-roster-list">
+              {!roster.length ? <div className="p-3 small npc-muted">No NPCs or merchants found. Use New Character to create one.</div> : null}
+              {roster.map((r) => {`,
+    "Empty roster message"
+  );
+
+  replaceOnce(
+`                      onDelete={() => handleDeleteNpc(selected?.id)}`,
+`                      onDelete={isAdmin && String(selected?.name || "").trim().toLowerCase() !== "mog" ? () => handleDeleteNpc(selected?.id) : null}`,
+    "Mog-safe delete control"
+  );
+
+  replaceOnce(
+`    <NewNpcModal
+        show={showNewNpcModal}
+        onClose={() => setShowNewNpcModal(false)}
+        onCreated={handleNewNpcCreated}
+      />`,
+`    <NewNpcModal
+        show={showNewNpcModal}
+        locations={locations}
+        onClose={() => setShowNewNpcModal(false)}
+        onCreated={handleNewNpcCreated}
+      />`,
+    "NPC Forge location options"
+  );
+
+  fs.writeFileSync(target, source, "utf8");
+  console.log("Connected the NPC page to the canonical NPC Forge create/delete paths.");
+} else {
+  console.log("NPC Forge page integration already present.");
+}
+
+for (const token of [
+  'supabase.rpc("delete_character_v1"',
+  'locations={locations}',
+  'New Character',
+  'Mog is protected',
+  'handleNewNpcCreated(created)',
+]) {
+  if (!source.includes(token)) throw new Error(`NPC Forge page validation failed: ${token}`);
+}
+
+for (const forbidden of ["setErrorMessage(", "selectedNpc", "setSelectedNpc", '.eq("character_id", characterId)']) {
+  if (source.includes(forbidden)) throw new Error(`Stale NPC delete path remains: ${forbidden}`);
+}

--- a/scripts/patch_professions_canonical_crafting.mjs
+++ b/scripts/patch_professions_canonical_crafting.mjs
@@ -1,4 +1,4 @@
-// Profession and crafting source-transformer entry point.
+// Profession, crafting, and canonical character source-transformer entry point.
 const transformers = [
   new URL("patch_professions_canonical_crafting_v2.mjs", import.meta.url),
   new URL("disambiguate_crafting_target_state.mjs", import.meta.url),
@@ -6,6 +6,7 @@ const transformers = [
   new URL("patch_enchanting_workshop.mjs", import.meta.url),
   new URL("patch_enchanting_catalog_consistency.mjs", import.meta.url),
   new URL("canonicalize_weapon_enchants.mjs", import.meta.url),
+  new URL("patch_npc_forge_page.mjs", import.meta.url),
 ];
 for (const transformer of transformers) {
   await import(transformer.href);

--- a/scripts/patch_professions_canonical_crafting.mjs
+++ b/scripts/patch_professions_canonical_crafting.mjs
@@ -1,5 +1,6 @@
 // Profession, crafting, and canonical character source-transformer entry point.
 const transformers = [
+  new URL("patch_character_creation_import.mjs", import.meta.url),
   new URL("patch_professions_canonical_crafting_v2.mjs", import.meta.url),
   new URL("disambiguate_crafting_target_state.mjs", import.meta.url),
   new URL("patch_self_crafting_professions.mjs", import.meta.url),

--- a/scripts/test_character_creation.mjs
+++ b/scripts/test_character_creation.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import {
+  BACKGROUND_DEFINITIONS,
+  CLASS_DEFINITIONS,
+  SPECIES_DEFINITIONS,
+  applyBackgroundAbilityBoosts,
+  buildCharacterCreatePayload,
+  buildCharacterSheetFromDraft,
+  defaultBackgroundBoosts,
+  maximumHitPoints,
+  proficiencyBonusForLevel,
+  standardAbilityScores,
+  validateCharacterDraft,
+  workshopTagsFromProfessions,
+} from "../utils/characterCreation.js";
+
+assert.deepEqual(Object.keys(SPECIES_DEFINITIONS).filter((key) => key !== "custom"), [
+  "aasimar", "dragonborn", "dwarf", "elf", "gnome", "goliath", "halfling", "human", "orc", "tiefling",
+]);
+assert.equal(CLASS_DEFINITIONS.civilian.label, "No Adventuring Class");
+assert.equal(BACKGROUND_DEFINITIONS.artisan.feat, "Crafter");
+assert.deepEqual(standardAbilityScores("fighter"), { str: 15, dex: 14, con: 13, int: 8, wis: 10, cha: 12 });
+assert.equal(proficiencyBonusForLevel(1), 2);
+assert.equal(proficiencyBonusForLevel(5), 3);
+assert.equal(proficiencyBonusForLevel(17), 6);
+assert.equal(maximumHitPoints({ classKey: "fighter", level: 5, constitutionScore: 14 }), 44);
+
+const boosts = defaultBackgroundBoosts("soldier", "fighter");
+const boosted = applyBackgroundAbilityBoosts(standardAbilityScores("fighter"), "soldier", boosts);
+assert.equal(boosted.str, 17);
+assert.equal(boosted.con, 14);
+
+const professions = {
+  alchemy: { rank: 1, ability: "int", offersService: true },
+  smithing: { rank: 2, ability: "str", offersService: true },
+  scribe: { rank: 0, ability: "int", offersService: false },
+  enchanting: { rank: 1, ability: "cha", offersService: false },
+};
+assert.deepEqual(workshopTagsFromProfessions(professions), ["alchemist", "blacksmith"]);
+assert.equal(workshopTagsFromProfessions({ jeweler: { rank: 2, offersService: true } }).includes("jeweler"), false);
+
+const draft = {
+  name: "Marta Ironroot",
+  kind: "merchant",
+  role: "Master Armorer",
+  affiliation: "Gray Hall Smiths' Guild",
+  speciesKey: "dwarf",
+  backgroundKey: "artisan",
+  classKey: "fighter",
+  level: 5,
+  baseAbilities: standardAbilityScores("fighter"),
+  backgroundBoosts: defaultBackgroundBoosts("artisan", "fighter"),
+  selectedClassSkills: ["athletics", "history"],
+  expertiseSkills: ["investigation"],
+  professions,
+  additionalFeats: ["Heavy Armor Master"],
+  storefrontEnabled: true,
+  storefrontTitle: "Ironroot Armory",
+  locationId: "56",
+};
+
+assert.deepEqual(validateCharacterDraft(draft), []);
+const sheet = buildCharacterSheetFromDraft(draft);
+assert.equal(sheet.className, "Fighter");
+assert.equal(sheet.level, 5);
+assert.equal(sheet.proficiencyBonus, 3);
+assert.equal(sheet.background, "Artisan");
+assert.equal(sheet.professions.smithing.rank, 2);
+assert.equal(sheet.proficiencies.skills.investigation.expertise, true);
+assert.equal(sheet.meta.creator, "npc_forge_v1");
+
+const payload = buildCharacterCreatePayload(draft);
+assert.equal(payload.kind, "merchant");
+assert.equal(payload.role, "Master Armorer", "in-world role must remain separate from class");
+assert.equal(payload.sheet.className, "Fighter");
+assert.equal(payload.storefront_enabled, true);
+assert.equal(payload.is_hidden, true, "new characters must start off-map");
+assert.deepEqual(payload.tags.sort(), ["alchemist", "blacksmith"]);
+assert.equal(payload.location_id, 56);
+
+const invalidServiceDraft = {
+  ...draft,
+  professions: {
+    ...professions,
+    scribe: { rank: 0, ability: "int", offersService: true },
+  },
+};
+assert.match(validateCharacterDraft(invalidServiceDraft).join(" "), /Scribe must be proficient/);
+
+const customDraft = {
+  ...draft,
+  name: "Skritch",
+  kind: "npc",
+  role: "Tunnel Scout",
+  speciesKey: "custom",
+  customSpecies: "Goblin",
+  backgroundKey: "custom",
+  customBackground: "Undercity Runner",
+  classKey: "rogue",
+  selectedClassSkills: ["acrobatics", "investigation", "sleightOfHand", "stealth"],
+  backgroundBoosts: { mode: "three", plusOnes: ["dex", "int", "wis"] },
+  professions: {},
+  locationId: "",
+};
+assert.deepEqual(validateCharacterDraft(customDraft), []);
+assert.equal(buildCharacterSheetFromDraft(customDraft).species, "Goblin");
+assert.equal(buildCharacterSheetFromDraft(customDraft).background, "Undercity Runner");
+
+console.log("Canonical NPC character creation model tests passed.");

--- a/scripts/test_character_creation.mjs
+++ b/scripts/test_character_creation.mjs
@@ -28,7 +28,8 @@ assert.equal(maximumHitPoints({ classKey: "fighter", level: 5, constitutionScore
 const boosts = defaultBackgroundBoosts("soldier", "fighter");
 const boosted = applyBackgroundAbilityBoosts(standardAbilityScores("fighter"), "soldier", boosts);
 assert.equal(boosted.str, 17);
-assert.equal(boosted.con, 14);
+assert.equal(boosted.dex, 15);
+assert.equal(boosted.con, 13);
 
 const professions = {
   alchemy: { rank: 1, ability: "int", offersService: true },

--- a/sql/20260617_02_npc_forge_foundation_v1.sql
+++ b/sql/20260617_02_npc_forge_foundation_v1.sql
@@ -1,0 +1,285 @@
+begin;
+
+create or replace function private.require_character_admin_v1()
+returns void
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private, auth
+as $function$
+begin
+  if coalesce(auth.role(), '') <> 'service_role' and not private.current_user_is_admin() then
+    raise exception 'Only an administrator can manage campaign characters' using errcode = '42501';
+  end if;
+end;
+$function$;
+
+create or replace function private.location_roster_character_id_v1(p_entry jsonb)
+returns text
+language sql
+immutable
+set search_path = pg_catalog
+as $function$
+  select case jsonb_typeof(p_entry)
+    when 'object' then nullif(p_entry->>'id', '')
+    when 'string' then nullif(p_entry #>> '{}', '')
+    else null
+  end;
+$function$;
+
+create or replace function public.create_character_v1(p_payload jsonb)
+returns uuid
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private, auth
+as $function$
+declare
+  v_payload jsonb := coalesce(p_payload, '{}'::jsonb);
+  v_sheet jsonb;
+  v_name text;
+  v_kind text;
+  v_status text;
+  v_location_id bigint;
+  v_character_id uuid;
+  v_tags text[] := '{}'::text[];
+  v_storefront_enabled boolean;
+begin
+  perform private.require_character_admin_v1();
+
+  if jsonb_typeof(v_payload) <> 'object' then
+    raise exception 'Character payload must be a JSON object';
+  end if;
+
+  v_name := btrim(coalesce(v_payload->>'name', ''));
+  if v_name = '' then
+    raise exception 'Character name is required';
+  end if;
+  if char_length(v_name) > 120 then
+    raise exception 'Character name must be 120 characters or fewer';
+  end if;
+  if exists (select 1 from public.characters where lower(name) = lower(v_name)) then
+    raise exception 'A character named % already exists', v_name using errcode = '23505';
+  end if;
+
+  v_kind := lower(coalesce(nullif(btrim(v_payload->>'kind'), ''), 'npc'));
+  if v_kind not in ('npc', 'merchant') then
+    raise exception 'Character kind must be npc or merchant';
+  end if;
+
+  v_status := lower(coalesce(nullif(btrim(v_payload->>'status'), ''), 'alive'));
+  if v_status not in ('alive', 'dead', 'missing', 'unknown') then
+    raise exception 'Invalid character status: %', v_status;
+  end if;
+
+  v_sheet := coalesce(v_payload->'sheet', '{}'::jsonb);
+  if jsonb_typeof(v_sheet) <> 'object' then
+    raise exception 'Character sheet must be a JSON object';
+  end if;
+
+  if nullif(v_payload->>'location_id', '') is not null then
+    begin
+      v_location_id := (v_payload->>'location_id')::bigint;
+    exception when invalid_text_representation then
+      raise exception 'Starting location must be a valid location id';
+    end;
+    if not exists (select 1 from public.locations where id = v_location_id) then
+      raise exception 'Starting location % was not found', v_location_id;
+    end if;
+  end if;
+
+  if jsonb_typeof(v_payload->'tags') = 'array' then
+    select coalesce(array_agg(distinct tag order by tag), '{}'::text[])
+    into v_tags
+    from (
+      select lower(btrim(value)) as tag
+      from jsonb_array_elements_text(v_payload->'tags')
+      where btrim(value) <> ''
+    ) normalized_tags;
+  end if;
+
+  v_storefront_enabled := v_kind = 'merchant' and coalesce((v_payload->>'storefront_enabled')::boolean, true);
+
+  insert into public.characters (
+    name,
+    race,
+    role,
+    description,
+    motivation,
+    quirk,
+    mannerism,
+    voice,
+    secret,
+    affiliation,
+    status,
+    background,
+    tags,
+    kind,
+    storefront_enabled,
+    storefront_title,
+    storefront_tagline,
+    location_id,
+    last_known_location_id,
+    home_location_id,
+    is_hidden,
+    state,
+    updated_at
+  ) values (
+    v_name,
+    nullif(btrim(v_payload->>'race'), ''),
+    nullif(btrim(v_payload->>'role'), ''),
+    nullif(btrim(v_payload->>'description'), ''),
+    nullif(btrim(v_payload->>'motivation'), ''),
+    nullif(btrim(v_payload->>'quirk'), ''),
+    nullif(btrim(v_payload->>'mannerism'), ''),
+    nullif(btrim(v_payload->>'voice'), ''),
+    nullif(btrim(v_payload->>'secret'), ''),
+    nullif(btrim(v_payload->>'affiliation'), ''),
+    v_status,
+    nullif(btrim(v_payload->>'background'), ''),
+    v_tags,
+    v_kind,
+    v_storefront_enabled,
+    case when v_storefront_enabled then nullif(btrim(v_payload->>'storefront_title'), '') else null end,
+    case when v_storefront_enabled then nullif(btrim(v_payload->>'storefront_tagline'), '') else null end,
+    v_location_id,
+    v_location_id,
+    v_location_id,
+    true,
+    'resting',
+    now()
+  )
+  returning id into v_character_id;
+
+  insert into public.character_sheets (character_id, sheet, updated_at)
+  values (
+    v_character_id,
+    v_sheet || jsonb_build_object(
+      'schemaVersion', coalesce(v_sheet->'schemaVersion', '1'::jsonb),
+      'meta', coalesce(v_sheet->'meta', '{}'::jsonb) || jsonb_build_object(
+        'characterId', v_character_id,
+        'createdBy', 'npc_forge_v1'
+      )
+    ),
+    now()
+  );
+
+  if v_location_id is not null then
+    update public.locations l
+    set npcs = coalesce(l.npcs, '[]'::jsonb) || jsonb_build_array(
+      jsonb_build_object('id', v_character_id::text, 'type', v_kind)
+    )
+    where l.id = v_location_id
+      and not exists (
+        select 1
+        from jsonb_array_elements(coalesce(l.npcs, '[]'::jsonb)) as roster(entry)
+        where private.location_roster_character_id_v1(roster.entry) = v_character_id::text
+      );
+  end if;
+
+  return v_character_id;
+end;
+$function$;
+
+create or replace function public.delete_character_v1(p_character_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public, private, auth
+as $function$
+declare
+  v_character public.characters%rowtype;
+  v_inventory_deleted integer := 0;
+  v_locations_cleaned integer := 0;
+begin
+  perform private.require_character_admin_v1();
+
+  select * into v_character
+  from public.characters
+  where id = p_character_id
+  for update;
+
+  if not found then
+    raise exception 'Character % was not found', p_character_id;
+  end if;
+
+  if v_character.id = 'c0a40081-9bab-402d-8437-62267e596c4f'::uuid
+     or lower(btrim(v_character.name)) = 'mog' then
+    raise exception 'Mog is protected and cannot be deleted' using errcode = '42501';
+  end if;
+
+  delete from public.inventory_items
+  where owner_id = p_character_id::text
+    and owner_type in ('npc', 'merchant', 'character');
+  get diagnostics v_inventory_deleted = row_count;
+
+  update public.locations l
+  set npcs = coalesce((
+    select jsonb_agg(roster.entry order by roster.ordinality)
+    from jsonb_array_elements(coalesce(l.npcs, '[]'::jsonb)) with ordinality as roster(entry, ordinality)
+    where private.location_roster_character_id_v1(roster.entry) is distinct from p_character_id::text
+  ), '[]'::jsonb)
+  where exists (
+    select 1
+    from jsonb_array_elements(coalesce(l.npcs, '[]'::jsonb)) as roster(entry)
+    where private.location_roster_character_id_v1(roster.entry) = p_character_id::text
+  );
+  get diagnostics v_locations_cleaned = row_count;
+
+  delete from public.characters where id = p_character_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'character_id', p_character_id,
+    'character_name', v_character.name,
+    'inventory_items_deleted', v_inventory_deleted,
+    'location_rosters_cleaned', v_locations_cleaned
+  );
+end;
+$function$;
+
+create or replace function private.protect_mog_delete_v1()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog, public
+as $function$
+begin
+  if old.id = 'c0a40081-9bab-402d-8437-62267e596c4f'::uuid
+     or lower(btrim(old.name)) = 'mog' then
+    raise exception 'Mog is protected and cannot be deleted' using errcode = '42501';
+  end if;
+  return old;
+end;
+$function$;
+
+drop trigger if exists protect_mog_delete_v1 on public.characters;
+create trigger protect_mog_delete_v1
+before delete on public.characters
+for each row execute function private.protect_mog_delete_v1();
+
+insert into public.character_sheets (character_id, sheet, updated_at)
+select
+  c.id,
+  jsonb_build_object(
+    'schemaVersion', 1,
+    'meta', jsonb_build_object(
+      'characterId', c.id,
+      'createdBy', 'sheet_backfill_v1'
+    )
+  ),
+  now()
+from public.characters c
+left join public.character_sheets cs on cs.character_id = c.id
+where cs.character_id is null
+on conflict (character_id) do nothing;
+
+revoke all on function public.create_character_v1(jsonb) from public;
+revoke all on function public.delete_character_v1(uuid) from public;
+grant execute on function public.create_character_v1(jsonb) to authenticated, service_role;
+grant execute on function public.delete_character_v1(uuid) to authenticated, service_role;
+
+comment on function public.create_character_v1(jsonb) is
+  'Atomically creates a canonical NPC or merchant and its character sheet. New characters start resting and off-map.';
+comment on function public.delete_character_v1(uuid) is
+  'Deletes an NPC or merchant and owned inventory while cleaning location rosters. Mog is protected.';
+
+commit;

--- a/styles/npc-forge.scss
+++ b/styles/npc-forge.scss
@@ -1,0 +1,708 @@
+.npc-forge-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(2, 4, 10, 0.86);
+  backdrop-filter: blur(10px);
+}
+
+.npc-forge-modal {
+  width: min(1480px, 98vw);
+  max-height: 95vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color: #f7f3ff;
+  border: 1px solid rgba(181, 133, 255, 0.34);
+  border-radius: 18px;
+  background:
+    radial-gradient(circle at 76% 8%, rgba(111, 57, 190, 0.24), transparent 30%),
+    linear-gradient(150deg, rgba(19, 14, 30, 0.99), rgba(7, 9, 17, 0.99));
+  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.64), inset 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.npc-forge-header,
+.npc-forge-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 18px 22px;
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(6, 7, 14, 0.64);
+}
+
+.npc-forge-header {
+  align-items: flex-start;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.npc-forge-header h2 {
+  margin: 2px 0 4px;
+  color: #fff;
+  font-size: clamp(1.35rem, 2vw, 1.9rem);
+}
+
+.npc-forge-header p {
+  max-width: 820px;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.64);
+  font-size: 0.86rem;
+}
+
+.npc-forge-kicker,
+.npc-forge-preview-label {
+  color: #c9a8ff;
+  font-size: 0.67rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.npc-forge-steps {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 1px;
+  padding: 0 22px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(3, 4, 9, 0.58);
+}
+
+.npc-forge-steps button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 48px;
+  padding: 7px 5px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: rgba(255, 255, 255, 0.47);
+  background: transparent;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.npc-forge-steps button span {
+  display: grid;
+  width: 21px;
+  height: 21px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 50%;
+  font-size: 0.65rem;
+}
+
+.npc-forge-steps button.is-current {
+  border-bottom-color: #ab70ff;
+  color: #fff;
+  background: rgba(142, 85, 226, 0.09);
+}
+
+.npc-forge-steps button.is-current span,
+.npc-forge-steps button.is-complete span {
+  border-color: #ab70ff;
+  color: #fff;
+  background: rgba(142, 85, 226, 0.36);
+}
+
+.npc-forge-steps button:disabled {
+  cursor: default;
+}
+
+.npc-forge-body {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 310px;
+  flex: 1;
+  overflow: hidden;
+}
+
+.npc-forge-workspace,
+.npc-forge-preview {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.npc-forge-workspace {
+  padding: 22px;
+}
+
+.npc-forge-preview {
+  padding: 20px;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  background:
+    linear-gradient(rgba(15, 10, 24, 0.9), rgba(9, 10, 17, 0.96)),
+    repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.025) 0 2px, transparent 2px 8px);
+}
+
+.npc-forge-preview h3 {
+  margin: 8px 0 2px;
+  color: #fff;
+  font-size: 1.12rem;
+}
+
+.npc-forge-preview > p {
+  margin: 0 0 14px;
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.76rem;
+}
+
+.npc-forge-section {
+  animation: npc-forge-enter 160ms ease-out;
+}
+
+@keyframes npc-forge-enter {
+  from { opacity: 0; transform: translateY(5px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.npc-forge-section-heading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+}
+
+.npc-forge-section-heading span,
+.npc-forge-subheading,
+.npc-forge-form-grid label > span,
+.npc-forge-inline-field > span,
+.npc-forge-level-row label > span,
+.npc-forge-profession label > span {
+  color: rgba(255, 255, 255, 0.56);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.npc-forge-section-heading h3 {
+  margin: 2px 0 0;
+  color: #fff;
+  font-size: 1.15rem;
+}
+
+.npc-forge-section-heading p {
+  max-width: 540px;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.76rem;
+  text-align: right;
+}
+
+.npc-forge-subheading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  color: #d6c2f4;
+}
+
+.npc-forge-subheading small {
+  color: rgba(255, 255, 255, 0.48);
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.npc-forge-choice-grid {
+  display: grid;
+  gap: 9px;
+}
+
+.npc-forge-choice-grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.npc-forge-choice-grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+.npc-forge-choice {
+  min-height: 92px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 11px;
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(255, 255, 255, 0.035);
+  text-align: left;
+  transition: border-color 130ms ease, background 130ms ease, transform 130ms ease;
+}
+
+.npc-forge-choice:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(190, 148, 255, 0.48);
+  background: rgba(156, 99, 237, 0.08);
+}
+
+.npc-forge-choice.is-active {
+  border-color: rgba(196, 151, 255, 0.86);
+  background: linear-gradient(145deg, rgba(129, 72, 214, 0.24), rgba(67, 41, 112, 0.13));
+  box-shadow: inset 0 0 0 1px rgba(197, 154, 255, 0.12), 0 6px 22px rgba(43, 21, 79, 0.2);
+}
+
+.npc-forge-choice-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.npc-forge-choice-head strong {
+  color: #fff;
+  font-size: 0.86rem;
+}
+
+.npc-forge-choice-badge {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border: 1px solid rgba(204, 167, 255, 0.34);
+  border-radius: 999px;
+  color: #d8bdff;
+  font-size: 0.62rem;
+  font-weight: 700;
+}
+
+.npc-forge-choice-body {
+  display: block;
+  margin-top: 7px;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.7rem;
+  line-height: 1.35;
+}
+
+.npc-forge-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.npc-forge-form-grid label,
+.npc-forge-inline-field,
+.npc-forge-level-row label {
+  display: grid;
+  gap: 5px;
+}
+
+.npc-forge-form-grid .wide { grid-column: 1 / -1; }
+
+.npc-forge-form-grid input,
+.npc-forge-form-grid select,
+.npc-forge-form-grid textarea,
+.npc-forge-inline-field input,
+.npc-forge-inline-field select,
+.npc-forge-level-row input,
+.npc-forge-profession select,
+.npc-forge-add-row input,
+.npc-forge-add-row select {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  color: #fff;
+  background: rgba(4, 5, 10, 0.72);
+  outline: none;
+}
+
+.npc-forge-form-grid input,
+.npc-forge-form-grid select,
+.npc-forge-inline-field input,
+.npc-forge-inline-field select,
+.npc-forge-level-row input,
+.npc-forge-profession select,
+.npc-forge-add-row input,
+.npc-forge-add-row select {
+  min-height: 38px;
+  padding: 7px 9px;
+}
+
+.npc-forge-form-grid textarea {
+  padding: 8px 9px;
+  resize: vertical;
+}
+
+.npc-forge-form-grid input:focus,
+.npc-forge-form-grid select:focus,
+.npc-forge-form-grid textarea:focus,
+.npc-forge-inline-field input:focus,
+.npc-forge-inline-field select:focus,
+.npc-forge-level-row input:focus,
+.npc-forge-profession select:focus,
+.npc-forge-add-row input:focus,
+.npc-forge-add-row select:focus {
+  border-color: #a96eff;
+  box-shadow: 0 0 0 3px rgba(151, 88, 240, 0.12);
+}
+
+.npc-forge-modal option {
+  color: #fff;
+  background: #17111f;
+}
+
+.npc-forge-level-row {
+  display: grid;
+  grid-template-columns: 130px repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.npc-forge-level-row > div {
+  display: grid;
+  min-height: 62px;
+  place-items: center;
+  align-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.npc-forge-level-row > div span {
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 0.64rem;
+  text-transform: uppercase;
+}
+
+.npc-forge-level-row > div strong {
+  color: #fff;
+  font-size: 1rem;
+}
+
+.npc-forge-segmented {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.npc-forge-segmented button,
+.npc-forge-chip-row button,
+.npc-forge-chip-row > span,
+.npc-forge-add-row button {
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 0.7rem;
+}
+
+.npc-forge-segmented button.is-active,
+.npc-forge-chip-row button.is-active {
+  border-color: #a970ff;
+  color: #fff;
+  background: rgba(142, 82, 231, 0.24);
+}
+
+.npc-forge-segmented.compact button { padding: 5px 9px; }
+
+.npc-forge-ability-grid,
+.npc-forge-final-abilities,
+.npc-forge-preview-abilities {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.npc-forge-ability-grid label {
+  display: grid;
+  justify-items: center;
+  gap: 5px;
+  padding: 10px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.npc-forge-ability-grid label span {
+  color: rgba(255, 255, 255, 0.58);
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.npc-forge-ability-grid input {
+  width: 58px;
+  min-height: 38px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 7px;
+  color: #fff;
+  background: rgba(3, 4, 8, 0.72);
+  text-align: center;
+}
+
+.npc-forge-ability-grid small {
+  color: #cab0ef;
+  font-size: 0.66rem;
+}
+
+.npc-forge-skill-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.npc-forge-skill-grid button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 39px;
+  padding: 7px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.76);
+  background: rgba(255, 255, 255, 0.035);
+  text-align: left;
+}
+
+.npc-forge-skill-grid button.is-active {
+  border-color: rgba(165, 111, 249, 0.75);
+  color: #fff;
+  background: rgba(126, 75, 202, 0.2);
+}
+
+.npc-forge-skill-grid button.is-background {
+  border-color: rgba(74, 191, 139, 0.45);
+  color: #c7ffe5;
+  background: rgba(33, 124, 85, 0.14);
+}
+
+.npc-forge-skill-grid button small {
+  color: rgba(255, 255, 255, 0.42);
+  font-size: 0.61rem;
+}
+
+.npc-forge-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.npc-forge-chip-row > span.is-fixed {
+  border-color: rgba(72, 189, 132, 0.42);
+  color: #c7ffe4;
+  background: rgba(37, 133, 91, 0.14);
+}
+
+.npc-forge-profession-list {
+  display: grid;
+  gap: 8px;
+}
+
+.npc-forge-profession {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) 150px 160px minmax(170px, 0.9fr);
+  align-items: end;
+  gap: 10px;
+  padding: 11px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.npc-forge-profession.is-provider {
+  border-color: rgba(216, 158, 71, 0.5);
+  background: linear-gradient(100deg, rgba(155, 91, 28, 0.16), rgba(89, 52, 128, 0.1));
+}
+
+.npc-forge-profession > div,
+.npc-forge-profession label:not(.npc-forge-service-toggle) {
+  display: grid;
+  gap: 4px;
+}
+
+.npc-forge-profession > div strong { color: #fff; }
+.npc-forge-profession > div small { color: rgba(255, 255, 255, 0.5); font-size: 0.67rem; }
+
+.npc-forge-service-toggle {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 38px;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.72rem;
+}
+
+.npc-forge-service-toggle input { accent-color: #a86cff; }
+
+.npc-forge-callout,
+.npc-forge-merchant-box {
+  padding: 11px;
+  border: 1px solid rgba(162, 109, 242, 0.27);
+  border-radius: 10px;
+  background: rgba(109, 64, 174, 0.09);
+}
+
+.npc-forge-callout {
+  display: grid;
+  gap: 3px;
+  align-content: center;
+}
+
+.npc-forge-callout strong { color: #e2d1fa; font-size: 0.76rem; }
+.npc-forge-callout span { color: rgba(255, 255, 255, 0.55); font-size: 0.68rem; line-height: 1.35; }
+
+.npc-forge-add-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 7px;
+}
+
+.npc-forge-add-row button {
+  border-radius: 8px;
+  color: #fff;
+  background: rgba(123, 74, 197, 0.23);
+}
+
+.npc-forge-review-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.npc-forge-review-grid article {
+  min-height: 112px;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.npc-forge-review-grid article > span {
+  color: #bfa0ed;
+  font-size: 0.64rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.npc-forge-review-grid article strong {
+  display: block;
+  margin-top: 6px;
+  color: #fff;
+  font-size: 0.86rem;
+}
+
+.npc-forge-review-grid article p {
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.69rem;
+  line-height: 1.38;
+}
+
+.npc-forge-final-abilities > div,
+.npc-forge-preview-abilities > div,
+.npc-forge-preview-stats > div {
+  display: grid;
+  justify-items: center;
+  gap: 1px;
+  padding: 7px 4px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.npc-forge-final-abilities span,
+.npc-forge-preview-abilities span,
+.npc-forge-preview-stats span {
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 0.57rem;
+  font-weight: 800;
+}
+
+.npc-forge-final-abilities strong,
+.npc-forge-preview-abilities strong,
+.npc-forge-preview-stats strong { color: #fff; }
+.npc-forge-final-abilities small { color: #c8a9f5; font-size: 0.62rem; }
+
+.npc-forge-json summary {
+  cursor: pointer;
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 0.72rem;
+}
+
+.npc-forge-json pre {
+  max-height: 300px;
+  margin-top: 8px;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 9px;
+  color: rgba(255, 255, 255, 0.74);
+  background: rgba(0, 0, 0, 0.32);
+  font-size: 0.67rem;
+}
+
+.npc-forge-preview-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 5px;
+  margin-bottom: 9px;
+}
+
+.npc-forge-preview-abilities { gap: 4px; }
+
+.npc-forge-preview-block {
+  display: grid;
+  gap: 3px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.npc-forge-preview-block > span {
+  color: #bfa0ea;
+  font-size: 0.61rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.npc-forge-preview-block strong { color: #fff; font-size: 0.78rem; }
+.npc-forge-preview-block small { color: rgba(255, 255, 255, 0.54); font-size: 0.66rem; line-height: 1.35; }
+
+.npc-forge-error {
+  margin: 0 22px 12px;
+  padding: 9px 11px;
+  border: 1px solid rgba(248, 113, 113, 0.42);
+  border-radius: 9px;
+  color: #ffd2d2;
+  background: rgba(153, 27, 27, 0.22);
+  font-size: 0.76rem;
+}
+
+.npc-forge-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.npc-forge-footer > div {
+  display: flex;
+  gap: 8px;
+}
+
+@media (max-width: 1120px) {
+  .npc-forge-body { grid-template-columns: 1fr; }
+  .npc-forge-preview { display: none; }
+  .npc-forge-choice-grid.three { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .npc-forge-profession { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 760px) {
+  .npc-forge-backdrop { padding: 0; }
+  .npc-forge-modal { width: 100vw; max-height: 100vh; height: 100vh; border: 0; border-radius: 0; }
+  .npc-forge-header, .npc-forge-footer { padding: 13px; }
+  .npc-forge-steps { grid-template-columns: repeat(7, 42px); overflow-x: auto; padding: 0 10px; }
+  .npc-forge-steps button { font-size: 0; }
+  .npc-forge-steps button span { font-size: 0.65rem; }
+  .npc-forge-workspace { padding: 14px; }
+  .npc-forge-section-heading { display: block; }
+  .npc-forge-section-heading p { margin-top: 6px; text-align: left; }
+  .npc-forge-choice-grid.two,
+  .npc-forge-choice-grid.three,
+  .npc-forge-form-grid,
+  .npc-forge-review-grid,
+  .npc-forge-skill-grid { grid-template-columns: 1fr; }
+  .npc-forge-level-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .npc-forge-ability-grid,
+  .npc-forge-final-abilities { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .npc-forge-profession { grid-template-columns: 1fr; }
+}

--- a/utils/characterCreation.js
+++ b/utils/characterCreation.js
@@ -1,0 +1,550 @@
+import { PROFESSION_DEFINITIONS, PROFESSION_KEYS, normalizeProfessionEntry } from "./craftingProfessions";
+
+export const ABILITY_KEYS = Object.freeze(["str", "dex", "con", "int", "wis", "cha"]);
+
+export const ABILITY_LABELS = Object.freeze({
+  str: "Strength",
+  dex: "Dexterity",
+  con: "Constitution",
+  int: "Intelligence",
+  wis: "Wisdom",
+  cha: "Charisma",
+});
+
+export const SKILL_DEFINITIONS = Object.freeze([
+  Object.freeze({ key: "acrobatics", label: "Acrobatics", ability: "dex" }),
+  Object.freeze({ key: "animalHandling", label: "Animal Handling", ability: "wis" }),
+  Object.freeze({ key: "arcana", label: "Arcana", ability: "int" }),
+  Object.freeze({ key: "athletics", label: "Athletics", ability: "str" }),
+  Object.freeze({ key: "deception", label: "Deception", ability: "cha" }),
+  Object.freeze({ key: "history", label: "History", ability: "int" }),
+  Object.freeze({ key: "insight", label: "Insight", ability: "wis" }),
+  Object.freeze({ key: "intimidation", label: "Intimidation", ability: "cha" }),
+  Object.freeze({ key: "investigation", label: "Investigation", ability: "int" }),
+  Object.freeze({ key: "medicine", label: "Medicine", ability: "wis" }),
+  Object.freeze({ key: "nature", label: "Nature", ability: "int" }),
+  Object.freeze({ key: "perception", label: "Perception", ability: "wis" }),
+  Object.freeze({ key: "performance", label: "Performance", ability: "cha" }),
+  Object.freeze({ key: "persuasion", label: "Persuasion", ability: "cha" }),
+  Object.freeze({ key: "religion", label: "Religion", ability: "int" }),
+  Object.freeze({ key: "sleightOfHand", label: "Sleight of Hand", ability: "dex" }),
+  Object.freeze({ key: "stealth", label: "Stealth", ability: "dex" }),
+  Object.freeze({ key: "survival", label: "Survival", ability: "wis" }),
+]);
+
+const ALL_SKILLS = Object.freeze(SKILL_DEFINITIONS.map((skill) => skill.key));
+
+export const CLASS_DEFINITIONS = Object.freeze({
+  civilian: Object.freeze({
+    key: "civilian",
+    label: "No Adventuring Class",
+    hitDie: 8,
+    primaryAbilities: Object.freeze([]),
+    savingThrows: Object.freeze([]),
+    skillCount: 2,
+    skillOptions: ALL_SKILLS,
+    spellcastingAbility: null,
+    summary: "A classless townsperson, professional, official, or other non-adventuring NPC.",
+  }),
+  barbarian: Object.freeze({
+    key: "barbarian", label: "Barbarian", hitDie: 12,
+    primaryAbilities: Object.freeze(["str"]), savingThrows: Object.freeze(["str", "con"]),
+    skillCount: 2, skillOptions: Object.freeze(["animalHandling", "athletics", "intimidation", "nature", "perception", "survival"]),
+    spellcastingAbility: null, summary: "A durable warrior driven by battle fury and raw physical power.",
+  }),
+  bard: Object.freeze({
+    key: "bard", label: "Bard", hitDie: 8,
+    primaryAbilities: Object.freeze(["cha"]), savingThrows: Object.freeze(["dex", "cha"]),
+    skillCount: 3, skillOptions: ALL_SKILLS, spellcastingAbility: "cha",
+    summary: "A versatile performer and spellcaster whose talents support allies and shape social encounters.",
+  }),
+  cleric: Object.freeze({
+    key: "cleric", label: "Cleric", hitDie: 8,
+    primaryAbilities: Object.freeze(["wis"]), savingThrows: Object.freeze(["wis", "cha"]),
+    skillCount: 2, skillOptions: Object.freeze(["history", "insight", "medicine", "persuasion", "religion"]),
+    spellcastingAbility: "wis", summary: "A divine spellcaster empowered by faith, doctrine, or sacred service.",
+  }),
+  druid: Object.freeze({
+    key: "druid", label: "Druid", hitDie: 8,
+    primaryAbilities: Object.freeze(["wis"]), savingThrows: Object.freeze(["int", "wis"]),
+    skillCount: 2, skillOptions: Object.freeze(["arcana", "animalHandling", "insight", "medicine", "nature", "perception", "religion", "survival"]),
+    spellcastingAbility: "wis", summary: "A primal spellcaster tied to nature, transformation, and the elemental world.",
+  }),
+  fighter: Object.freeze({
+    key: "fighter", label: "Fighter", hitDie: 10,
+    primaryAbilities: Object.freeze(["str", "dex"]), savingThrows: Object.freeze(["str", "con"]),
+    skillCount: 2, skillOptions: Object.freeze(["acrobatics", "animalHandling", "athletics", "history", "insight", "intimidation", "perception", "survival"]),
+    spellcastingAbility: null, summary: "A trained combatant defined by weapon mastery and battlefield discipline.",
+  }),
+  monk: Object.freeze({
+    key: "monk", label: "Monk", hitDie: 8,
+    primaryAbilities: Object.freeze(["dex", "wis"]), savingThrows: Object.freeze(["str", "dex"]),
+    skillCount: 2, skillOptions: Object.freeze(["acrobatics", "athletics", "history", "insight", "religion", "stealth"]),
+    spellcastingAbility: null, summary: "A disciplined martial artist who channels focus through body and spirit.",
+  }),
+  paladin: Object.freeze({
+    key: "paladin", label: "Paladin", hitDie: 10,
+    primaryAbilities: Object.freeze(["str", "cha"]), savingThrows: Object.freeze(["wis", "cha"]),
+    skillCount: 2, skillOptions: Object.freeze(["athletics", "insight", "intimidation", "medicine", "persuasion", "religion"]),
+    spellcastingAbility: "cha", summary: "An armored champion whose oath fuels martial and divine power.",
+  }),
+  ranger: Object.freeze({
+    key: "ranger", label: "Ranger", hitDie: 10,
+    primaryAbilities: Object.freeze(["dex", "wis"]), savingThrows: Object.freeze(["str", "dex"]),
+    skillCount: 3, skillOptions: Object.freeze(["animalHandling", "athletics", "insight", "investigation", "nature", "perception", "stealth", "survival"]),
+    spellcastingAbility: "wis", summary: "A mobile hunter and explorer skilled in wilderness, tracking, and primal magic.",
+  }),
+  rogue: Object.freeze({
+    key: "rogue", label: "Rogue", hitDie: 8,
+    primaryAbilities: Object.freeze(["dex"]), savingThrows: Object.freeze(["dex", "int"]),
+    skillCount: 4, skillOptions: Object.freeze(["acrobatics", "athletics", "deception", "insight", "intimidation", "investigation", "perception", "persuasion", "sleightOfHand", "stealth"]),
+    spellcastingAbility: null, summary: "A precise specialist who relies on expertise, agility, and opportunistic attacks.",
+  }),
+  sorcerer: Object.freeze({
+    key: "sorcerer", label: "Sorcerer", hitDie: 6,
+    primaryAbilities: Object.freeze(["cha"]), savingThrows: Object.freeze(["con", "cha"]),
+    skillCount: 2, skillOptions: Object.freeze(["arcana", "deception", "insight", "intimidation", "persuasion", "religion"]),
+    spellcastingAbility: "cha", summary: "An innate spellcaster whose magic flows from bloodline, transformation, or supernatural origin.",
+  }),
+  warlock: Object.freeze({
+    key: "warlock", label: "Warlock", hitDie: 8,
+    primaryAbilities: Object.freeze(["cha"]), savingThrows: Object.freeze(["wis", "cha"]),
+    skillCount: 2, skillOptions: Object.freeze(["arcana", "deception", "history", "intimidation", "investigation", "nature", "religion"]),
+    spellcastingAbility: "cha", summary: "An occult spellcaster empowered by a pact, patron, or forbidden source.",
+  }),
+  wizard: Object.freeze({
+    key: "wizard", label: "Wizard", hitDie: 6,
+    primaryAbilities: Object.freeze(["int"]), savingThrows: Object.freeze(["int", "wis"]),
+    skillCount: 2, skillOptions: Object.freeze(["arcana", "history", "insight", "investigation", "medicine", "nature", "religion"]),
+    spellcastingAbility: "int", summary: "A learned spellcaster who studies, records, and prepares arcane magic.",
+  }),
+});
+
+export const CLASS_KEYS = Object.freeze(Object.keys(CLASS_DEFINITIONS));
+
+export const STANDARD_ARRAYS_BY_CLASS = Object.freeze({
+  civilian: Object.freeze({ str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 }),
+  barbarian: Object.freeze({ str: 15, dex: 13, con: 14, int: 10, wis: 12, cha: 8 }),
+  bard: Object.freeze({ str: 8, dex: 14, con: 12, int: 13, wis: 10, cha: 15 }),
+  cleric: Object.freeze({ str: 14, dex: 8, con: 13, int: 10, wis: 15, cha: 12 }),
+  druid: Object.freeze({ str: 8, dex: 12, con: 14, int: 13, wis: 15, cha: 10 }),
+  fighter: Object.freeze({ str: 15, dex: 14, con: 13, int: 8, wis: 10, cha: 12 }),
+  monk: Object.freeze({ str: 12, dex: 15, con: 13, int: 10, wis: 14, cha: 8 }),
+  paladin: Object.freeze({ str: 15, dex: 10, con: 13, int: 8, wis: 12, cha: 14 }),
+  ranger: Object.freeze({ str: 12, dex: 15, con: 13, int: 8, wis: 14, cha: 10 }),
+  rogue: Object.freeze({ str: 12, dex: 15, con: 13, int: 14, wis: 10, cha: 8 }),
+  sorcerer: Object.freeze({ str: 10, dex: 13, con: 14, int: 8, wis: 12, cha: 15 }),
+  warlock: Object.freeze({ str: 8, dex: 14, con: 13, int: 12, wis: 10, cha: 15 }),
+  wizard: Object.freeze({ str: 8, dex: 12, con: 13, int: 15, wis: 14, cha: 10 }),
+});
+
+export const SPECIES_DEFINITIONS = Object.freeze({
+  aasimar: Object.freeze({ key: "aasimar", label: "Aasimar", speed: 30, lineages: Object.freeze([]), traits: Object.freeze(["Celestial Resistance", "Darkvision", "Healing Hands", "Light Bearer", "Celestial Revelation at level 3"]) }),
+  dragonborn: Object.freeze({ key: "dragonborn", label: "Dragonborn", speed: 30, lineages: Object.freeze(["Black", "Blue", "Brass", "Bronze", "Copper", "Gold", "Green", "Red", "Silver", "White"]), traits: Object.freeze(["Draconic Ancestry", "Breath Weapon", "Damage Resistance", "Darkvision", "Draconic Flight at level 5"]) }),
+  dwarf: Object.freeze({ key: "dwarf", label: "Dwarf", speed: 30, lineages: Object.freeze([]), traits: Object.freeze(["Darkvision", "Dwarven Resilience", "Dwarven Toughness", "Stonecunning"]) }),
+  elf: Object.freeze({ key: "elf", label: "Elf", speed: 30, lineages: Object.freeze(["Drow", "High Elf", "Wood Elf"]), traits: Object.freeze(["Darkvision", "Elven Lineage", "Fey Ancestry", "Keen Senses", "Trance"]) }),
+  gnome: Object.freeze({ key: "gnome", label: "Gnome", speed: 30, lineages: Object.freeze(["Forest Gnome", "Rock Gnome"]), traits: Object.freeze(["Darkvision", "Gnomish Cunning", "Gnomish Lineage"]) }),
+  goliath: Object.freeze({ key: "goliath", label: "Goliath", speed: 35, lineages: Object.freeze(["Cloud Giant", "Fire Giant", "Frost Giant", "Hill Giant", "Stone Giant", "Storm Giant"]), traits: Object.freeze(["Giant Ancestry", "Large Form at level 5", "Powerful Build"]) }),
+  halfling: Object.freeze({ key: "halfling", label: "Halfling", speed: 30, lineages: Object.freeze([]), traits: Object.freeze(["Brave", "Halfling Nimbleness", "Luck", "Naturally Stealthy"]) }),
+  human: Object.freeze({ key: "human", label: "Human", speed: 30, lineages: Object.freeze([]), traits: Object.freeze(["Resourceful", "Skillful", "Versatile"]) }),
+  orc: Object.freeze({ key: "orc", label: "Orc", speed: 30, lineages: Object.freeze([]), traits: Object.freeze(["Adrenaline Rush", "Darkvision", "Relentless Endurance"]) }),
+  tiefling: Object.freeze({ key: "tiefling", label: "Tiefling", speed: 30, lineages: Object.freeze(["Abyssal", "Chthonic", "Infernal"]), traits: Object.freeze(["Darkvision", "Fiendish Legacy", "Otherworldly Presence"]) }),
+  custom: Object.freeze({ key: "custom", label: "Custom / Campaign Species", speed: 30, lineages: Object.freeze([]), traits: Object.freeze([]) }),
+});
+
+export const SPECIES_KEYS = Object.freeze(Object.keys(SPECIES_DEFINITIONS));
+
+export const BACKGROUND_DEFINITIONS = Object.freeze({
+  acolyte: Object.freeze({ key: "acolyte", label: "Acolyte", abilities: Object.freeze(["int", "wis", "cha"]), feat: "Magic Initiate (Cleric)", skills: Object.freeze(["insight", "religion"]), tool: "Calligrapher's Supplies" }),
+  artisan: Object.freeze({ key: "artisan", label: "Artisan", abilities: Object.freeze(["str", "dex", "int"]), feat: "Crafter", skills: Object.freeze(["investigation", "persuasion"]), tool: "Artisan's Tools" }),
+  charlatan: Object.freeze({ key: "charlatan", label: "Charlatan", abilities: Object.freeze(["dex", "con", "cha"]), feat: "Skilled", skills: Object.freeze(["deception", "sleightOfHand"]), tool: "Forgery Kit" }),
+  criminal: Object.freeze({ key: "criminal", label: "Criminal", abilities: Object.freeze(["dex", "con", "int"]), feat: "Alert", skills: Object.freeze(["sleightOfHand", "stealth"]), tool: "Thieves' Tools" }),
+  entertainer: Object.freeze({ key: "entertainer", label: "Entertainer", abilities: Object.freeze(["str", "dex", "cha"]), feat: "Musician", skills: Object.freeze(["acrobatics", "performance"]), tool: "Musical Instrument" }),
+  farmer: Object.freeze({ key: "farmer", label: "Farmer", abilities: Object.freeze(["str", "con", "wis"]), feat: "Tough", skills: Object.freeze(["animalHandling", "nature"]), tool: "Carpenter's Tools" }),
+  guard: Object.freeze({ key: "guard", label: "Guard", abilities: Object.freeze(["str", "int", "wis"]), feat: "Alert", skills: Object.freeze(["athletics", "perception"]), tool: "Gaming Set" }),
+  guide: Object.freeze({ key: "guide", label: "Guide", abilities: Object.freeze(["dex", "con", "wis"]), feat: "Magic Initiate (Druid)", skills: Object.freeze(["stealth", "survival"]), tool: "Cartographer's Tools" }),
+  hermit: Object.freeze({ key: "hermit", label: "Hermit", abilities: Object.freeze(["con", "wis", "cha"]), feat: "Healer", skills: Object.freeze(["medicine", "religion"]), tool: "Herbalism Kit" }),
+  merchant: Object.freeze({ key: "merchant", label: "Merchant", abilities: Object.freeze(["con", "int", "cha"]), feat: "Lucky", skills: Object.freeze(["animalHandling", "persuasion"]), tool: "Navigator's Tools" }),
+  noble: Object.freeze({ key: "noble", label: "Noble", abilities: Object.freeze(["str", "int", "cha"]), feat: "Skilled", skills: Object.freeze(["history", "persuasion"]), tool: "Gaming Set" }),
+  sage: Object.freeze({ key: "sage", label: "Sage", abilities: Object.freeze(["con", "int", "wis"]), feat: "Magic Initiate (Wizard)", skills: Object.freeze(["arcana", "history"]), tool: "Calligrapher's Supplies" }),
+  sailor: Object.freeze({ key: "sailor", label: "Sailor", abilities: Object.freeze(["str", "dex", "wis"]), feat: "Tavern Brawler", skills: Object.freeze(["acrobatics", "perception"]), tool: "Navigator's Tools" }),
+  scribe: Object.freeze({ key: "scribe", label: "Scribe", abilities: Object.freeze(["dex", "int", "wis"]), feat: "Skilled", skills: Object.freeze(["investigation", "perception"]), tool: "Calligrapher's Supplies" }),
+  soldier: Object.freeze({ key: "soldier", label: "Soldier", abilities: Object.freeze(["str", "dex", "con"]), feat: "Savage Attacker", skills: Object.freeze(["athletics", "intimidation"]), tool: "Gaming Set" }),
+  wayfarer: Object.freeze({ key: "wayfarer", label: "Wayfarer", abilities: Object.freeze(["dex", "wis", "cha"]), feat: "Lucky", skills: Object.freeze(["insight", "stealth"]), tool: "Thieves' Tools" }),
+  custom: Object.freeze({ key: "custom", label: "Custom / No Standard Background", abilities: Object.freeze(ABILITY_KEYS), feat: "", skills: Object.freeze([]), tool: "" }),
+});
+
+export const BACKGROUND_KEYS = Object.freeze(Object.keys(BACKGROUND_DEFINITIONS));
+
+export const FEAT_OPTIONS = Object.freeze([
+  { name: "Alert", category: "Origin", minimumLevel: 1 },
+  { name: "Crafter", category: "Origin", minimumLevel: 1 },
+  { name: "Healer", category: "Origin", minimumLevel: 1 },
+  { name: "Lucky", category: "Origin", minimumLevel: 1 },
+  { name: "Magic Initiate", category: "Origin", minimumLevel: 1, repeatable: true },
+  { name: "Musician", category: "Origin", minimumLevel: 1 },
+  { name: "Savage Attacker", category: "Origin", minimumLevel: 1 },
+  { name: "Skilled", category: "Origin", minimumLevel: 1, repeatable: true },
+  { name: "Tavern Brawler", category: "Origin", minimumLevel: 1 },
+  { name: "Tough", category: "Origin", minimumLevel: 1 },
+  { name: "Ability Score Improvement", category: "General", minimumLevel: 4, repeatable: true },
+  { name: "Actor", category: "General", minimumLevel: 4 },
+  { name: "Athlete", category: "General", minimumLevel: 4 },
+  { name: "Charger", category: "General", minimumLevel: 4 },
+  { name: "Chef", category: "General", minimumLevel: 4 },
+  { name: "Crossbow Expert", category: "General", minimumLevel: 4 },
+  { name: "Crusher", category: "General", minimumLevel: 4 },
+  { name: "Defensive Duelist", category: "General", minimumLevel: 4 },
+  { name: "Dual Wielder", category: "General", minimumLevel: 4 },
+  { name: "Durable", category: "General", minimumLevel: 4 },
+  { name: "Elemental Adept", category: "General", minimumLevel: 4, repeatable: true },
+  { name: "Fey-Touched", category: "General", minimumLevel: 4 },
+  { name: "Grappler", category: "General", minimumLevel: 4 },
+  { name: "Great Weapon Master", category: "General", minimumLevel: 4 },
+  { name: "Heavily Armored", category: "General", minimumLevel: 4 },
+  { name: "Heavy Armor Master", category: "General", minimumLevel: 4 },
+  { name: "Inspiring Leader", category: "General", minimumLevel: 4 },
+  { name: "Keen Mind", category: "General", minimumLevel: 4 },
+  { name: "Lightly Armored", category: "General", minimumLevel: 4 },
+  { name: "Mage Slayer", category: "General", minimumLevel: 4 },
+  { name: "Martial Weapon Training", category: "General", minimumLevel: 4 },
+  { name: "Medium Armor Master", category: "General", minimumLevel: 4 },
+  { name: "Moderately Armored", category: "General", minimumLevel: 4 },
+  { name: "Mounted Combatant", category: "General", minimumLevel: 4 },
+  { name: "Observant", category: "General", minimumLevel: 4 },
+  { name: "Piercer", category: "General", minimumLevel: 4 },
+  { name: "Poisoner", category: "General", minimumLevel: 4 },
+  { name: "Polearm Master", category: "General", minimumLevel: 4 },
+  { name: "Resilient", category: "General", minimumLevel: 4 },
+  { name: "Ritual Caster", category: "General", minimumLevel: 4 },
+  { name: "Sentinel", category: "General", minimumLevel: 4 },
+  { name: "Shadow-Touched", category: "General", minimumLevel: 4 },
+  { name: "Sharpshooter", category: "General", minimumLevel: 4 },
+  { name: "Shield Master", category: "General", minimumLevel: 4 },
+  { name: "Skill Expert", category: "General", minimumLevel: 4 },
+  { name: "Skulker", category: "General", minimumLevel: 4 },
+  { name: "Slasher", category: "General", minimumLevel: 4 },
+  { name: "Speedy", category: "General", minimumLevel: 4 },
+  { name: "Spell Sniper", category: "General", minimumLevel: 4 },
+  { name: "Telekinetic", category: "General", minimumLevel: 4 },
+  { name: "Telepathic", category: "General", minimumLevel: 4 },
+  { name: "War Caster", category: "General", minimumLevel: 4 },
+  { name: "Weapon Master", category: "General", minimumLevel: 4 },
+]);
+
+export const PROFESSION_SERVICE_TAGS = Object.freeze({
+  alchemy: "alchemist",
+  smithing: "blacksmith",
+  scribe: "scribe",
+  enchanting: "enchanter",
+});
+
+function finiteInt(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.round(number) : fallback;
+}
+
+export function clampCharacterLevel(value) {
+  return Math.max(1, Math.min(20, finiteInt(value, 1)));
+}
+
+export function clampAbilityScore(value) {
+  return Math.max(1, Math.min(30, finiteInt(value, 10)));
+}
+
+export function proficiencyBonusForLevel(level) {
+  return 2 + Math.floor((clampCharacterLevel(level) - 1) / 4);
+}
+
+export function abilityModifierForScore(score) {
+  return Math.floor((clampAbilityScore(score) - 10) / 2);
+}
+
+export function roll4d6DropLowest(random = Math.random) {
+  const rolls = Array.from({ length: 4 }, () => Math.floor(random() * 6) + 1).sort((a, b) => a - b);
+  return rolls[1] + rolls[2] + rolls[3];
+}
+
+export function rollAbilitySet(random = Math.random) {
+  return Object.fromEntries(ABILITY_KEYS.map((key) => [key, roll4d6DropLowest(random)]));
+}
+
+export function standardAbilityScores(classKey = "civilian") {
+  const source = STANDARD_ARRAYS_BY_CLASS[classKey] || STANDARD_ARRAYS_BY_CLASS.civilian;
+  return { ...source };
+}
+
+export function normalizeAbilityScores(value = {}) {
+  return Object.fromEntries(ABILITY_KEYS.map((key) => [key, clampAbilityScore(value?.[key]?.score ?? value?.[key] ?? 10)]));
+}
+
+export function applyBackgroundAbilityBoosts(baseScores = {}, backgroundKey = "custom", boosts = {}) {
+  const background = BACKGROUND_DEFINITIONS[backgroundKey] || BACKGROUND_DEFINITIONS.custom;
+  const allowed = new Set(background.abilities);
+  const normalized = normalizeAbilityScores(baseScores);
+  const result = { ...normalized };
+  const mode = boosts.mode === "three" ? "three" : "twoOne";
+
+  if (mode === "three") {
+    const selected = Array.from(new Set(Array.isArray(boosts.plusOnes) ? boosts.plusOnes : []))
+      .filter((ability) => allowed.has(ability))
+      .slice(0, 3);
+    selected.forEach((ability) => {
+      result[ability] = Math.min(20, result[ability] + 1);
+    });
+  } else {
+    const plusTwo = allowed.has(boosts.plusTwo) ? boosts.plusTwo : null;
+    const plusOne = allowed.has(boosts.plusOne) && boosts.plusOne !== plusTwo ? boosts.plusOne : null;
+    if (plusTwo) result[plusTwo] = Math.min(20, result[plusTwo] + 2);
+    if (plusOne) result[plusOne] = Math.min(20, result[plusOne] + 1);
+  }
+
+  return result;
+}
+
+export function defaultBackgroundBoosts(backgroundKey = "custom", classKey = "civilian") {
+  const background = BACKGROUND_DEFINITIONS[backgroundKey] || BACKGROUND_DEFINITIONS.custom;
+  const classDefinition = CLASS_DEFINITIONS[classKey] || CLASS_DEFINITIONS.civilian;
+  const preferred = [
+    ...classDefinition.primaryAbilities,
+    "con",
+    "dex",
+    "wis",
+    "int",
+    "cha",
+    "str",
+  ].filter((ability, index, values) => values.indexOf(ability) === index && background.abilities.includes(ability));
+  return {
+    mode: "twoOne",
+    plusTwo: preferred[0] || background.abilities[0] || "str",
+    plusOne: preferred[1] || background.abilities.find((ability) => ability !== preferred[0]) || "dex",
+    plusOnes: background.abilities.slice(0, 3),
+  };
+}
+
+export function maximumHitPoints({ classKey = "civilian", level = 1, constitutionScore = 10 } = {}) {
+  const classDefinition = CLASS_DEFINITIONS[classKey] || CLASS_DEFINITIONS.civilian;
+  const resolvedLevel = clampCharacterLevel(level);
+  const constitutionModifier = abilityModifierForScore(constitutionScore);
+  const firstLevel = Math.max(1, classDefinition.hitDie + constitutionModifier);
+  const laterLevelAverage = Math.floor(classDefinition.hitDie / 2) + 1;
+  const laterLevelGain = Math.max(1, laterLevelAverage + constitutionModifier);
+  return firstLevel + Math.max(0, resolvedLevel - 1) * laterLevelGain;
+}
+
+export function normalizeSelectedSkills(classKey = "civilian", selectedSkills = [], backgroundKey = "custom") {
+  const classDefinition = CLASS_DEFINITIONS[classKey] || CLASS_DEFINITIONS.civilian;
+  const background = BACKGROUND_DEFINITIONS[backgroundKey] || BACKGROUND_DEFINITIONS.custom;
+  const allowed = new Set(classDefinition.skillOptions);
+  const classSkills = Array.from(new Set(Array.isArray(selectedSkills) ? selectedSkills : []))
+    .filter((skill) => allowed.has(skill))
+    .slice(0, classDefinition.skillCount);
+  return Array.from(new Set([...background.skills, ...classSkills]));
+}
+
+export function professionConfiguration(value = {}) {
+  return Object.fromEntries(PROFESSION_KEYS.map((key) => {
+    const raw = value?.[key] || {};
+    const normalized = normalizeProfessionEntry(raw, key);
+    return [key, {
+      rank: normalized?.rank || 0,
+      ability: normalized?.ability || PROFESSION_DEFINITIONS[key].abilities[0],
+      offersService: Boolean(raw?.offersService ?? raw?.offers_service),
+    }];
+  }));
+}
+
+export function workshopTagsFromProfessions(value = {}) {
+  const professions = professionConfiguration(value);
+  return PROFESSION_KEYS
+    .filter((key) => professions[key].rank > 0 && professions[key].offersService)
+    .map((key) => PROFESSION_SERVICE_TAGS[key]);
+}
+
+function cleanText(value) {
+  return String(value ?? "").trim();
+}
+
+function cleanTextArray(value) {
+  return Array.from(new Set((Array.isArray(value) ? value : []).map(cleanText).filter(Boolean)));
+}
+
+function speciesLabel(speciesKey, customSpecies) {
+  if (speciesKey === "custom") return cleanText(customSpecies) || "Custom Species";
+  return SPECIES_DEFINITIONS[speciesKey]?.label || "Unknown Species";
+}
+
+function classLabel(classKey) {
+  return CLASS_DEFINITIONS[classKey]?.label || CLASS_DEFINITIONS.civilian.label;
+}
+
+function backgroundLabel(backgroundKey, customBackground) {
+  if (backgroundKey === "custom") return cleanText(customBackground) || "Custom Background";
+  return BACKGROUND_DEFINITIONS[backgroundKey]?.label || BACKGROUND_DEFINITIONS.custom.label;
+}
+
+export function buildCharacterSheetFromDraft(draft = {}) {
+  const classKey = CLASS_DEFINITIONS[draft.classKey] ? draft.classKey : "civilian";
+  const backgroundKey = BACKGROUND_DEFINITIONS[draft.backgroundKey] ? draft.backgroundKey : "custom";
+  const speciesKey = SPECIES_DEFINITIONS[draft.speciesKey] ? draft.speciesKey : "custom";
+  const classDefinition = CLASS_DEFINITIONS[classKey];
+  const background = BACKGROUND_DEFINITIONS[backgroundKey];
+  const species = SPECIES_DEFINITIONS[speciesKey];
+  const level = clampCharacterLevel(draft.level);
+  const baseScores = normalizeAbilityScores(draft.baseAbilities || STANDARD_ARRAYS_BY_CLASS[classKey]);
+  const finalScores = applyBackgroundAbilityBoosts(baseScores, backgroundKey, draft.backgroundBoosts || defaultBackgroundBoosts(backgroundKey, classKey));
+  const skills = normalizeSelectedSkills(classKey, draft.selectedClassSkills, backgroundKey);
+  const professionData = professionConfiguration(draft.professions);
+  const allFeats = cleanTextArray([background.feat, ...(draft.additionalFeats || [])]);
+  const resolvedSpecies = speciesLabel(speciesKey, draft.customSpecies);
+  const resolvedBackground = backgroundLabel(backgroundKey, draft.customBackground);
+  const lineage = cleanText(draft.lineage);
+  const hitPoints = maximumHitPoints({ classKey, level, constitutionScore: finalScores.con });
+  const proficiencyBonus = proficiencyBonusForLevel(level);
+  const speciesTraits = [...species.traits];
+  const extraTraits = cleanTextArray(draft.extraTraits);
+  const traitLines = [
+    ...allFeats.map((feat) => `Feat: ${feat}`),
+    ...speciesTraits.map((trait) => `Species: ${trait}`),
+    ...extraTraits,
+  ];
+  const proficiencies = {
+    saves: Object.fromEntries(ABILITY_KEYS.map((key) => [key, { proficient: classDefinition.savingThrows.includes(key) }])),
+    skills: Object.fromEntries(SKILL_DEFINITIONS.map((skill) => [skill.key, {
+      proficient: skills.includes(skill.key),
+      expertise: Array.isArray(draft.expertiseSkills) && draft.expertiseSkills.includes(skill.key),
+    }])),
+  };
+  const spellcasting = classDefinition.spellcastingAbility ? {
+    ability: classDefinition.spellcastingAbility,
+    abilityLabel: ABILITY_LABELS[classDefinition.spellcastingAbility],
+    spellSaveDc: 8 + proficiencyBonus + abilityModifierForScore(finalScores[classDefinition.spellcastingAbility]),
+    spellAttackBonus: proficiencyBonus + abilityModifierForScore(finalScores[classDefinition.spellcastingAbility]),
+    preparedSpellsText: cleanText(draft.preparedSpellsText),
+    catalogStatus: "manual_until_spell_catalog_import",
+  } : null;
+
+  return {
+    schemaVersion: 1,
+    meta: {
+      classKey,
+      className: classLabel(classKey),
+      level,
+      speciesKey,
+      species: resolvedSpecies,
+      lineage: lineage || null,
+      backgroundKey,
+      background: resolvedBackground,
+      originFeat: background.feat || null,
+      toolProficiency: background.tool || null,
+      creator: "npc_forge_v1",
+    },
+    classKey,
+    className: classLabel(classKey),
+    class: classLabel(classKey),
+    level,
+    species: resolvedSpecies,
+    race: resolvedSpecies,
+    lineage: lineage || null,
+    background: resolvedBackground,
+    proficiencyBonus,
+    abilities: Object.fromEntries(ABILITY_KEYS.map((key) => [key, { score: finalScores[key] }])),
+    proficiencies,
+    professions: Object.fromEntries(PROFESSION_KEYS.map((key) => [key, {
+      rank: professionData[key].rank,
+      ability: professionData[key].ability,
+    }])),
+    speed: finiteInt(draft.speed, species.speed),
+    hp: finiteInt(draft.currentHp, hitPoints),
+    maxHp: finiteInt(draft.maxHp, hitPoints),
+    tempHp: 0,
+    hitDice: `${level}d${classDefinition.hitDie}`,
+    feats: allFeats,
+    speciesTraits,
+    featsTraits: traitLines.join("\n"),
+    tools: cleanTextArray([background.tool, ...(draft.additionalTools || [])]),
+    attacks: cleanText(draft.attacks),
+    equipment: "",
+    spellcasting,
+    spells: cleanText(draft.preparedSpellsText),
+    personality: {
+      traits: cleanText(draft.personalityTraits),
+      ideals: cleanText(draft.ideals),
+      bonds: cleanText(draft.bonds),
+      flaws: cleanText(draft.flaws),
+    },
+    traits: cleanText(draft.personalityTraits),
+    ideals: cleanText(draft.ideals),
+    bonds: cleanText(draft.bonds),
+    flaws: cleanText(draft.flaws),
+  };
+}
+
+export function buildCharacterCreatePayload(draft = {}) {
+  const name = cleanText(draft.name);
+  const kind = draft.kind === "merchant" ? "merchant" : "npc";
+  const sheet = buildCharacterSheetFromDraft(draft);
+  const professionTags = workshopTagsFromProfessions(draft.professions);
+  const tags = cleanTextArray([...(draft.tags || []), ...professionTags]);
+  const locationId = draft.locationId === "" || draft.locationId === null || draft.locationId === undefined
+    ? null
+    : Number(draft.locationId);
+
+  return {
+    name,
+    kind,
+    race: sheet.species,
+    role: cleanText(draft.role) || (kind === "merchant" ? "Merchant" : sheet.className),
+    affiliation: cleanText(draft.affiliation) || null,
+    status: "alive",
+    description: cleanText(draft.description) || null,
+    background: cleanText(draft.backgroundNarrative) || sheet.background,
+    motivation: cleanText(draft.motivation) || null,
+    quirk: cleanText(draft.quirk) || null,
+    mannerism: cleanText(draft.mannerism) || null,
+    voice: cleanText(draft.voice) || null,
+    secret: cleanText(draft.secret) || null,
+    tags,
+    storefront_enabled: kind === "merchant" ? Boolean(draft.storefrontEnabled ?? true) : false,
+    storefront_title: kind === "merchant" && Boolean(draft.storefrontEnabled ?? true) ? cleanText(draft.storefrontTitle) || `${name}'s Shop` : null,
+    storefront_tagline: kind === "merchant" && Boolean(draft.storefrontEnabled ?? true) ? cleanText(draft.storefrontTagline) || null : null,
+    location_id: Number.isFinite(locationId) ? locationId : null,
+    home_location_id: Number.isFinite(locationId) ? locationId : null,
+    is_hidden: true,
+    state: "resting",
+    sheet,
+  };
+}
+
+export function validateCharacterDraft(draft = {}) {
+  const errors = [];
+  if (!cleanText(draft.name)) errors.push("Name is required.");
+  if (cleanText(draft.name).length > 120) errors.push("Name must be 120 characters or fewer.");
+  if (!SPECIES_DEFINITIONS[draft.speciesKey]) errors.push("Choose a species.");
+  if (draft.speciesKey === "custom" && !cleanText(draft.customSpecies)) errors.push("Enter the custom species name.");
+  if (!BACKGROUND_DEFINITIONS[draft.backgroundKey]) errors.push("Choose a background.");
+  if (!CLASS_DEFINITIONS[draft.classKey]) errors.push("Choose a class or No Adventuring Class.");
+  const classDefinition = CLASS_DEFINITIONS[draft.classKey] || CLASS_DEFINITIONS.civilian;
+  const selectedClassSkills = Array.from(new Set(Array.isArray(draft.selectedClassSkills) ? draft.selectedClassSkills : []));
+  if (selectedClassSkills.length !== classDefinition.skillCount) {
+    errors.push(`Choose exactly ${classDefinition.skillCount} class skill${classDefinition.skillCount === 1 ? "" : "s"}.`);
+  }
+  if (selectedClassSkills.some((skill) => !classDefinition.skillOptions.includes(skill))) {
+    errors.push("One or more selected class skills are not available to that class.");
+  }
+  const background = BACKGROUND_DEFINITIONS[draft.backgroundKey] || BACKGROUND_DEFINITIONS.custom;
+  const boosts = draft.backgroundBoosts || {};
+  if (boosts.mode === "three") {
+    const plusOnes = Array.from(new Set(Array.isArray(boosts.plusOnes) ? boosts.plusOnes : [])).filter((key) => background.abilities.includes(key));
+    if (plusOnes.length !== 3) errors.push("Choose three different background abilities for +1 increases.");
+  } else if (!background.abilities.includes(boosts.plusTwo) || !background.abilities.includes(boosts.plusOne) || boosts.plusTwo === boosts.plusOne) {
+    errors.push("Choose different eligible background abilities for the +2 and +1 increases.");
+  }
+  const professionData = professionConfiguration(draft.professions);
+  PROFESSION_KEYS.forEach((key) => {
+    if (professionData[key].offersService && professionData[key].rank === 0) {
+      errors.push(`${PROFESSION_DEFINITIONS[key].label} must be proficient before it can be offered as a workshop service.`);
+    }
+  });
+  return errors;
+}


### PR DESCRIPTION
## Summary
- Replaces the primitive NPC wizard with a canonical NPC Forge for NPCs, merchants, and explicit workshop providers.
- Keeps in-world role/title separate from class.
- Adds 2024 core species, backgrounds, classes, standard arrays, background ability increases, class saves/skills, feat selection, professions, story hooks, storefront setup, and optional starting location.
- Limits Professions to Alchemy, Smithing, Scribe, and Enchanting.
- Requires a real trained Profession before an NPC can be exposed as a workshop provider.
- Creates character and sheet atomically through `create_character_v1`.
- Adds canonical `delete_character_v1` using the owner-type/owner-id inventory model and database cascades.
- Protects Mog at both the UI and database-trigger layers.
- Backfills missing `character_sheets` rows without deleting or replacing any NPCs.
- Fixes the existing NPC delete path's undefined state setters and invalid `inventory_items.character_id` assumption.
- Keeps the NPC page available when the roster is empty so a new campaign roster can be created later.

## Scope protection
- No NPC or merchant records are removed in this phase.
- No routes, movement functions, sprites, travel timing, or world-map rendering files are changed.
- New characters start off-map (`is_hidden = true`) and resting.
- Merchant storefront capability remains attached to the same canonical character record.

## Validation plan
- Character-creation model tests.
- Transformer syntax and second-pass idempotence.
- Production Next.js build.
- Rolled-back Supabase create/delete tests, including Mog protection and location-roster cleanup.
- Live migration only after all checks pass.