### PR TITLE
Tighten NPC Forge detail source validation

### DIFF
--- a/.github/workflows/validate-npc-forge.yml
+++ b/.github/workflows/validate-npc-forge.yml
@@ -10,6 +10,7 @@ on:
       - "pages/_app.js"
       - "styles/npc-forge.scss"
       - "utils/characterCreation.js"
+      - "utils/craftingProfessions.js"
       - "scripts/test_character_creation.mjs"
       - "scripts/test_npc_forge_character_creation.mjs"
       - "scripts/patch_character_creation_import.mjs"
@@ -28,6 +29,7 @@ on:
       - "pages/_app.js"
       - "styles/npc-forge.scss"
       - "utils/characterCreation.js"
+      - "utils/craftingProfessions.js"
       - "scripts/test_character_creation.mjs"
       - "scripts/test_npc_forge_character_creation.mjs"
       - "scripts/patch_character_creation_import.mjs"
@@ -62,12 +64,45 @@ jobs:
       - name: Validate JavaScript syntax
         run: |
           node --check utils/characterCreation.js
+          node --check utils/craftingProfessions.js
           node --check scripts/test_character_creation.mjs
           node --check scripts/test_npc_forge_character_creation.mjs
           node --check scripts/patch_character_creation_import.mjs
           node --check scripts/patch_npc_forge_page.mjs
           node --check scripts/patch_npc_forge_creation_details.mjs
           node --check scripts/patch_professions_canonical_crafting.mjs
+
+      - name: Validate NPC Forge detail transformer is inert
+        run: |
+          grep -Fq "NPC Forge detail source mutation is intentionally disabled" scripts/patch_npc_forge_creation_details.mjs
+          ! grep -Fq "fs.writeFileSync" scripts/patch_npc_forge_creation_details.mjs
+          ! grep -Fq "modalSource.replace" scripts/patch_npc_forge_creation_details.mjs
+          ! grep -Fq "characterSource.replace" scripts/patch_npc_forge_creation_details.mjs
+
+      - name: Validate canonical NPC Forge detail source markers
+        run: |
+          grep -Fq "export const ALIGNMENT_OPTIONS" utils/characterCreation.js
+          grep -Fq "export const SIZE_OPTIONS" utils/characterCreation.js
+          grep -Fq "function normalizeAlignment" utils/characterCreation.js
+          grep -Fq "function normalizeCharacterSize" utils/characterCreation.js
+          grep -Fq "function normalizeLanguages" utils/characterCreation.js
+          grep -Fq "appearance: cleanText(draft.appearance)" utils/characterCreation.js
+          grep -Fq "equipment: cleanText(draft.equipment)" utils/characterCreation.js
+          grep -Fq "treasure: cleanText(draft.treasure)" utils/characterCreation.js
+          grep -Fq "ALIGNMENT_OPTIONS," components/NewNpcModal.js
+          grep -Fq "SIZE_OPTIONS," components/NewNpcModal.js
+          grep -Fq "size: \"\"" components/NewNpcModal.js
+          grep -Fq "alignment: \"N\"" components/NewNpcModal.js
+          grep -Fq "languagesText: \"Common\"" components/NewNpcModal.js
+          grep -Fq "appearance: \"\"" components/NewNpcModal.js
+          grep -Fq "equipment: \"\"" components/NewNpcModal.js
+          grep -Fq "treasure: \"\"" components/NewNpcModal.js
+          grep -Fq "<span>Size</span><select value={draft.size}" components/NewNpcModal.js
+          grep -Fq "<span>Alignment</span><select value={draft.alignment}" components/NewNpcModal.js
+          grep -Fq "<span>Languages</span><input value={draft.languagesText}" components/NewNpcModal.js
+          grep -Fq "<span>Appearance</span><textarea" components/NewNpcModal.js
+          grep -Fq "<span>Equipment</span><textarea" components/NewNpcModal.js
+          grep -Fq "<span>Treasure / coin</span><input value={draft.treasure}" components/NewNpcModal.js
 
       - name: Normalize direct Node import
         run: node scripts/patch_character_creation_import.mjs
@@ -96,28 +131,29 @@ jobs:
 
       - name: Validate migration safety markers
         run: |
-          grep -q "create_character_v1" sql/20260617_02_npc_forge_foundation_v1.sql
-          grep -q "delete_character_v1" sql/20260617_02_npc_forge_foundation_v1.sql
-          grep -q "protect_mog_delete_v1" sql/20260617_02_npc_forge_foundation_v1.sql
-          grep -q "owner_id = p_character_id::text" sql/20260617_02_npc_forge_foundation_v1.sql
-          grep -q "character_sheets" sql/20260617_02_npc_forge_foundation_v1.sql
+          grep -Fq "create_character_v1" sql/20260617_02_npc_forge_foundation_v1.sql
+          grep -Fq "delete_character_v1" sql/20260617_02_npc_forge_foundation_v1.sql
+          grep -Fq "protect_mog_delete_v1" sql/20260617_02_npc_forge_foundation_v1.sql
+          grep -Fq "owner_id = p_character_id::text" sql/20260617_02_npc_forge_foundation_v1.sql
+          grep -Fq "character_sheets" sql/20260617_02_npc_forge_foundation_v1.sql
 
       - name: Validate generated NPC page integration
         run: |
-          grep -q 'supabase.rpc("delete_character_v1"' pages/npcs.js
-          grep -q 'locations={locations}' pages/npcs.js
-          grep -q 'New Character' pages/npcs.js
-          ! grep -q 'setErrorMessage(' pages/npcs.js
-          ! grep -q 'selectedNpc' pages/npcs.js
-          ! grep -q 'setSelectedNpc' pages/npcs.js
+          grep -Fq 'supabase.rpc("delete_character_v1"' pages/npcs.js
+          grep -Fq 'locations={locations}' pages/npcs.js
+          grep -Fq 'New Character' pages/npcs.js
+          ! grep -Fq 'setErrorMessage(' pages/npcs.js
+          ! grep -Fq 'selectedNpc' pages/npcs.js
+          ! grep -Fq 'setSelectedNpc' pages/npcs.js
 
-      - name: Validate generated NPC Forge detail fields
+      - name: Validate generated NPC Forge detail fields after transformers
         run: |
-          grep -q "ALIGNMENT_OPTIONS" utils/characterCreation.js
-          grep -q "SIZE_OPTIONS" utils/characterCreation.js
-          grep -q "languagesText" components/NewNpcModal.js
-          grep -q "Appearance" components/NewNpcModal.js
-          grep -q "Treasure / coin" components/NewNpcModal.js
+          grep -Fq "ALIGNMENT_OPTIONS" utils/characterCreation.js
+          grep -Fq "SIZE_OPTIONS" utils/characterCreation.js
+          grep -Fq "languagesText" components/NewNpcModal.js
+          grep -Fq "Appearance" components/NewNpcModal.js
+          grep -Fq "Treasure / coin" components/NewNpcModal.js
+          grep -Fq "<span>Languages</span><input value={draft.languagesText}" components/NewNpcModal.js
 
       - name: Stage first-pass generated sources
         run: git add --all


### PR DESCRIPTION
## Summary
- Strengthens the NPC Forge validation workflow around the new checked-in detail source.
- Validates that the disabled detail transformer remains inert and cannot mutate generated source.
- Checks source markers for size, alignment, languages, appearance, equipment, and treasure before and after prebuild.
- Adds `utils/craftingProfessions.js` to the workflow trigger/syntax check because the NPC Forge model imports it.

## Safety
- Workflow-only change.
- No app runtime code changes.
- No Supabase changes.
- No data changes.
- No world-map files touched.
- Vercel passed on branch commit `15352d4`.