### PR TITLE
Tighten town workshop provider eligibility

### DIFF
--- a/.github/workflows/validate-npc-forge.yml
+++ b/.github/workflows/validate-npc-forge.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "components/NewNpcModal.js"
+      - "components/TownSheet.js"
       - "pages/npcs.js"
       - "pages/_app.js"
       - "styles/npc-forge.scss"
@@ -17,6 +18,7 @@ on:
       - "scripts/patch_npc_forge_page.mjs"
       - "scripts/patch_npc_forge_creation_details.mjs"
       - "scripts/patch_professions_canonical_crafting.mjs"
+      - "scripts/patch_town_merchant_storefront.mjs"
       - "sql/20260617_02_npc_forge_foundation_v1.sql"
       - "package.json"
       - ".github/workflows/validate-npc-forge.yml"
@@ -25,6 +27,7 @@ on:
       - main
     paths:
       - "components/NewNpcModal.js"
+      - "components/TownSheet.js"
       - "pages/npcs.js"
       - "pages/_app.js"
       - "styles/npc-forge.scss"
@@ -36,6 +39,7 @@ on:
       - "scripts/patch_npc_forge_page.mjs"
       - "scripts/patch_npc_forge_creation_details.mjs"
       - "scripts/patch_professions_canonical_crafting.mjs"
+      - "scripts/patch_town_merchant_storefront.mjs"
       - "sql/20260617_02_npc_forge_foundation_v1.sql"
       - "package.json"
       - ".github/workflows/validate-npc-forge.yml"
@@ -71,6 +75,7 @@ jobs:
           node --check scripts/patch_npc_forge_page.mjs
           node --check scripts/patch_npc_forge_creation_details.mjs
           node --check scripts/patch_professions_canonical_crafting.mjs
+          node --check scripts/patch_town_merchant_storefront.mjs
 
       - name: Validate NPC Forge detail transformer is inert
         run: |
@@ -103,6 +108,18 @@ jobs:
           grep -Fq "<span>Appearance</span><textarea" components/NewNpcModal.js
           grep -Fq "<span>Equipment</span><textarea" components/NewNpcModal.js
           grep -Fq "<span>Treasure / coin</span><input value={draft.treasure}" components/NewNpcModal.js
+
+      - name: Validate strict provider source markers
+        run: |
+          grep -Fq "function collectExplicitProviderText" utils/craftingProfessions.js
+          grep -Fq "function professionServicesFromSheet" utils/craftingProfessions.js
+          grep -Fq "Name, role, affiliation, and storefront copy must not create workshop access." utils/craftingProfessions.js
+          grep -Fq "offers_service: resolved.offersService" utils/craftingProfessions.js
+          ! grep -Fq "character.role," utils/craftingProfessions.js
+          ! grep -Fq "character.affiliation," utils/craftingProfessions.js
+          grep -Fq "TownSheet strict workshop provider inference" scripts/patch_town_merchant_storefront.mjs
+          grep -Fq "availableProfessionsForCharacter(crafter)" scripts/patch_town_merchant_storefront.mjs
+          grep -Fq "PROFESSION_TO_CRAFT_TYPE" scripts/patch_town_merchant_storefront.mjs
 
       - name: Normalize direct Node import
         run: node scripts/patch_character_creation_import.mjs
@@ -154,6 +171,13 @@ jobs:
           grep -Fq "Appearance" components/NewNpcModal.js
           grep -Fq "Treasure / coin" components/NewNpcModal.js
           grep -Fq "<span>Languages</span><input value={draft.languagesText}" components/NewNpcModal.js
+
+      - name: Validate generated Town Sheet workshop providers
+        run: |
+          grep -Fq 'from "../utils/craftingProfessions"' components/TownSheet.js
+          grep -Fq "availableProfessionsForCharacter(crafter)" components/TownSheet.js
+          grep -Fq "PROFESSION_TO_CRAFT_TYPE" components/TownSheet.js
+          ! grep -Fq '["blacksmith", "alchemist", "enchanter", "scribe", "jeweler"]' components/TownSheet.js
 
       - name: Stage first-pass generated sources
         run: git add --all

--- a/scripts/patch_town_merchant_storefront.mjs
+++ b/scripts/patch_town_merchant_storefront.mjs
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 function replaceOnce(source, before, after, label) {
+  if (source.includes(after)) return source;
   const count = source.split(before).length - 1;
   if (count !== 1) {
     throw new Error(`${label}: expected one match, found ${count}`);
@@ -104,11 +105,60 @@ if (!town.includes("const MerchantPanel = dynamic(() => import(\"./MerchantPanel
     "TownSheet merchant modal"
   );
 
-  fs.writeFileSync(townPath, town, "utf8");
   console.log("Applied Town Sheet merchant storefront modal patch.");
 } else {
   console.log("Town Sheet merchant storefront modal patch already present.");
 }
+
+if (!town.includes('from "../utils/craftingProfessions"')) {
+  town = replaceOnce(
+    town,
+    'import { buildTownData } from "../utils/townData";',
+    'import { buildTownData } from "../utils/townData";\nimport { availableProfessionsForCharacter } from "../utils/craftingProfessions";',
+    "TownSheet workshop provider import"
+  );
+}
+
+if (!town.includes("const PROFESSION_TO_CRAFT_TYPE")) {
+  town = replaceOnce(
+    town,
+    `function inferCrafterTypes(crafter) {
+  const types = new Set();
+  collectCrafterRoleValues(crafter).forEach((value) => {
+    const type = inferCraftTypeFromText(value);
+    if (type) types.add(type);
+  });
+  return Array.from(types);
+}
+`,
+    `const PROFESSION_TO_CRAFT_TYPE = Object.freeze({
+  alchemy: "alchemist",
+  smithing: "blacksmith",
+  enchanting: "enchanter",
+  scribe: "scribe",
+});
+
+function inferCrafterTypes(crafter) {
+  return availableProfessionsForCharacter(crafter)
+    .map((profession) => PROFESSION_TO_CRAFT_TYPE[profession])
+    .filter(Boolean);
+}
+`,
+    "TownSheet strict workshop provider inference"
+  );
+}
+
+town = town.replace(
+  'if (![
+"blacksmith", "alchemist", "enchanter", "scribe", "jeweler"].some((type) => types.includes(type))) continue;',
+  'if (!["blacksmith", "alchemist", "enchanter", "scribe"].some((type) => types.includes(type))) continue;'
+);
+town = town.replace(
+  'if (!["blacksmith", "alchemist", "enchanter", "scribe", "jeweler"].some((type) => types.includes(type))) continue;',
+  'if (!["blacksmith", "alchemist", "enchanter", "scribe"].some((type) => types.includes(type))) continue;'
+);
+
+fs.writeFileSync(townPath, town, "utf8");
 
 const merchantPath = path.join(process.cwd(), "components", "MerchantPanel.js");
 let merchant = fs.readFileSync(merchantPath, "utf8");
@@ -155,8 +205,13 @@ const checks = [
   [town, 'onBrowseWares={setActiveMerchant}', "TownSheet merchant callback"],
   [town, '<MerchantPanel merchant={activeMerchant}', "TownSheet merchant modal"],
   [town, 'onClick={() => onBrowseWares?.(merchant)}', "merchant browse button"],
+  [town, 'availableProfessionsForCharacter(crafter)', "strict workshop provider helper"],
+  [town, 'PROFESSION_TO_CRAFT_TYPE', "canonical profession-to-craft mapping"],
   [merchant, 'onClose?.()', "MerchantPanel close callback"],
 ];
 for (const [source, token, label] of checks) {
   if (!source.includes(token)) throw new Error(`${label} validation failed`);
+}
+if (town.includes('["blacksmith", "alchemist", "enchanter", "scribe", "jeweler"]')) {
+  throw new Error("Jeweler must not be part of canonical workshop provider discovery.");
 }

--- a/scripts/patch_town_merchant_storefront.mjs
+++ b/scripts/patch_town_merchant_storefront.mjs
@@ -149,11 +149,6 @@ function inferCrafterTypes(crafter) {
 }
 
 town = town.replace(
-  'if (![
-"blacksmith", "alchemist", "enchanter", "scribe", "jeweler"].some((type) => types.includes(type))) continue;',
-  'if (!["blacksmith", "alchemist", "enchanter", "scribe"].some((type) => types.includes(type))) continue;'
-);
-town = town.replace(
   'if (!["blacksmith", "alchemist", "enchanter", "scribe", "jeweler"].some((type) => types.includes(type))) continue;',
   'if (!["blacksmith", "alchemist", "enchanter", "scribe"].some((type) => types.includes(type))) continue;'
 );

--- a/scripts/test_character_creation.mjs
+++ b/scripts/test_character_creation.mjs
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
 import {
+  availableProfessionsForCharacter,
+  professionModifierFromSheet,
+  providerOffersProfession,
+} from "../utils/craftingProfessions.js";
+import {
   BACKGROUND_DEFINITIONS,
   CLASS_DEFINITIONS,
   SPECIES_DEFINITIONS,
@@ -39,6 +44,22 @@ const professions = {
 };
 assert.deepEqual(workshopTagsFromProfessions(professions), ["alchemist", "blacksmith"]);
 assert.equal(workshopTagsFromProfessions({ jeweler: { rank: 2, offersService: true } }).includes("jeweler"), false);
+
+assert.deepEqual(availableProfessionsForCharacter({ role: "Master Armorer", name: "Blacksmith Bob", affiliation: "Smith Guild" }), []);
+assert.deepEqual(availableProfessionsForCharacter({ tags: ["blacksmith", "alchemist"] }).sort(), ["alchemy", "smithing"]);
+assert.equal(providerOffersProfession({ tags: ["blacksmith"] }, "smithing"), true);
+assert.equal(providerOffersProfession({ role: "Blacksmith" }, "smithing"), false);
+assert.deepEqual(availableProfessionsForCharacter({}, {
+  professions: {
+    smithing: { rank: 1, ability: "str", offersService: true },
+    enchanting: { rank: 1, ability: "int", offersService: false },
+  },
+}), ["smithing"]);
+assert.equal(professionModifierFromSheet({
+  proficiencyBonus: 3,
+  abilities: { str: { score: 16 } },
+  professions: { smithing: { rank: 2, ability: "str", offersService: true } },
+}, "smithing").totalModifier, 9);
 
 const draft = {
   name: "Marta Ironroot",

--- a/utils/craftingProfessions.js
+++ b/utils/craftingProfessions.js
@@ -60,6 +60,13 @@ function normalizedToken(value = "") {
     .trim();
 }
 
+function normalizeBoolean(value) {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  const token = normalizedToken(value);
+  return ["true", "yes", "y", "1", "on", "enabled", "service", "provider", "offers service"].includes(token);
+}
+
 export function normalizeProfessionKey(value = "") {
   const token = normalizedToken(value).replace(/\s+/g, "");
   if (token === "alchemist" || token === "alchemy") return "alchemy";
@@ -104,10 +111,19 @@ export function normalizeProfessionEntry(value, professionKey) {
     ? requestedAbility
     : definition.abilities[0];
   const rank = normalizeProfessionRank(raw.rank ?? raw.proficiency_rank ?? raw.tier ?? raw.proficient);
+  const offersService = normalizeBoolean(
+    raw.offersService
+      ?? raw.offers_service
+      ?? raw.workshopService
+      ?? raw.workshop_service
+      ?? raw.provider
+      ?? raw.offers
+  );
 
   return {
     rank,
     ability,
+    offersService,
   };
 }
 
@@ -146,21 +162,22 @@ export function professionModifierFromSheet(sheet = {}, professionKey) {
     proficiencyBonus,
     rank: profession.rank,
     rankLabel: profession.rank === 2 ? "Expertise" : profession.rank === 1 ? "Proficient" : "Untrained",
+    offersService: profession.offersService,
     proficiencyContribution,
     totalModifier: abilityMod + proficiencyContribution,
     configured: explicitlyConfigured && profession.rank > 0,
   };
 }
 
-function collectProviderText(character = {}) {
-  const values = [];
-  const push = (value) => {
-    if (!value) return;
-    if (Array.isArray(value)) return value.forEach(push);
-    if (typeof value === "object") return Object.values(value).forEach(push);
-    values.push(String(value));
-  };
+function pushProviderValue(values, value) {
+  if (!value) return;
+  if (Array.isArray(value)) return value.forEach((entry) => pushProviderValue(values, entry));
+  if (typeof value === "object") return Object.values(value).forEach((entry) => pushProviderValue(values, entry));
+  values.push(String(value));
+}
 
+function collectExplicitProviderText(character = {}) {
+  const values = [];
   [
     character.crafterTypes,
     character.craft_roles,
@@ -173,31 +190,64 @@ function collectProviderText(character = {}) {
     character.craftingRoles,
     character.services,
     character.tags,
-    character.role,
-    character.affiliation,
-    character.storefront_title,
-    character.storefront_tagline,
-    character.name,
-  ].forEach(push);
+  ].forEach((value) => pushProviderValue(values, value));
 
   return normalizedToken(values.join(" | "));
 }
 
-export function availableProfessionsForCharacter(character = {}) {
-  const blob = collectProviderText(character);
+function sheetFromCharacter(character = {}) {
+  if (character?.sheet && typeof character.sheet === "object") return character.sheet;
+  if (character?.characterSheet && typeof character.characterSheet === "object") return character.characterSheet;
+  if (character?.character_sheet && typeof character.character_sheet === "object") return character.character_sheet;
+  if (character?.character_sheets?.sheet && typeof character.character_sheets.sheet === "object") return character.character_sheets.sheet;
+  if (Array.isArray(character?.character_sheets) && character.character_sheets[0]?.sheet) return character.character_sheets[0].sheet;
+  return null;
+}
+
+function professionHasServiceFlag(value) {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value) && (
+    Object.prototype.hasOwnProperty.call(value, "offersService")
+    || Object.prototype.hasOwnProperty.call(value, "offers_service")
+    || Object.prototype.hasOwnProperty.call(value, "workshopService")
+    || Object.prototype.hasOwnProperty.call(value, "workshop_service")
+    || Object.prototype.hasOwnProperty.call(value, "provider")
+    || Object.prototype.hasOwnProperty.call(value, "offers")
+  ));
+}
+
+function professionServicesFromSheet(sheet = {}) {
+  const rawProfessions = sheet?.professions && typeof sheet.professions === "object" ? sheet.professions : null;
+  if (!rawProfessions) return null;
+
+  const hasServiceFlags = PROFESSION_KEYS.some((key) => professionHasServiceFlag(rawProfessions[key]));
+  if (!hasServiceFlags) return null;
+
+  return PROFESSION_KEYS.filter((key) => {
+    const entry = normalizeProfessionEntry(rawProfessions[key], key);
+    return entry?.rank > 0 && entry.offersService;
+  });
+}
+
+export function availableProfessionsForCharacter(character = {}, sheetOverride = null) {
+  const sheetProfessions = professionServicesFromSheet(sheetOverride || sheetFromCharacter(character));
+  if (sheetProfessions) return sheetProfessions;
+
+  const blob = collectExplicitProviderText(character);
   const result = new Set();
 
-  if (/\b(alchemist|alchemy|potion maker|potioner|poisoner|brewer|apothecary|herbalist|tonic maker)\b/.test(blob)) result.add("alchemy");
-  if (/\b(blacksmith|weaponsmith|weapon smith|armorsmith|armor smith|armorer|armourer|bladesmith|forge master|forgemaster|smithy|anvil|smithing)\b/.test(blob)) result.add("smithing");
-  if (/\b(enchanter|enchantress|enchanting|enchantment|imbuer|imbuement|runecrafter|rune crafter|runesmith|rune smith|rune carver|arcane artisan|spellwright)\b/.test(blob)) result.add("enchanting");
-  if (/\b(scribe|scrivener|scroll scribe|scrollwright|calligrapher|illuminator|ritual copyist|inscriber)\b/.test(blob)) result.add("scribe");
+  // Legacy fallback is intentionally limited to explicit service/tag fields.
+  // Name, role, affiliation, and storefront copy must not create workshop access.
+  if (/\b(alchemist|alchemy)\b/.test(blob)) result.add("alchemy");
+  if (/\b(blacksmith|smithing)\b/.test(blob)) result.add("smithing");
+  if (/\b(enchanter|enchanting)\b/.test(blob)) result.add("enchanting");
+  if (/\b(scribe|scribing)\b/.test(blob)) result.add("scribe");
 
   return Array.from(result);
 }
 
-export function providerOffersProfession(character, professionKey) {
+export function providerOffersProfession(character, professionKey, sheetOverride = null) {
   const key = normalizeProfessionKey(professionKey);
-  return Boolean(key && availableProfessionsForCharacter(character).includes(key));
+  return Boolean(key && availableProfessionsForCharacter(character, sheetOverride).includes(key));
 }
 
 export function buildCrafterProfessionSnapshot(character, sheet, professionKey) {
@@ -216,6 +266,7 @@ export function buildCrafterProfessionSnapshot(character, sheet, professionKey) 
     proficiency_bonus: resolved.proficiencyBonus,
     proficiency_rank: resolved.rank,
     proficiency_rank_label: resolved.rankLabel,
+    offers_service: resolved.offersService,
     total_modifier: resolved.totalModifier,
     tool: resolved.tool,
     configured: resolved.configured,


### PR DESCRIPTION
## Summary
- Makes `utils/craftingProfessions.js` resolve provider eligibility from explicit sheet service flags first.
- Restricts the fallback provider detection to explicit service/tag fields only.
- Prevents name, role, affiliation, and storefront copy from creating workshop access.
- Updates Town Sheet prebuild generation to use the shared strict provider resolver and only expose the four canonical provider types.
- Adds model tests covering role/name false positives and explicit tag/sheet service positives.
- Expands NPC Forge validation workflow checks for strict workshop provider generation.

## Safety
- No Supabase changes.
- No data changes.
- No NPC deletion.
- No world-map files touched.
- Vercel passed on branch commit `b300108`.