### PR TITLE
Improve merchant themes and NPC crafter shop presentation

### DIFF
--- a/scripts/patch_crafter_shop_presentation.mjs
+++ b/scripts/patch_crafter_shop_presentation.mjs
@@ -11,6 +11,10 @@ function replaceOnce(source, before, after, label) {
   return source.replace(before, after);
 }
 
+function replaceAllSafe(source, before, after) {
+  return source.split(before).join(after);
+}
+
 const itemsPath = path.join(process.cwd(), "pages", "items.js");
 let source = fs.readFileSync(itemsPath, "utf8");
 let changed = false;
@@ -33,15 +37,23 @@ const providerBefore = [
 const providerAfter = [
   '          <div className="craft-kicker">Crafter\'s Counter</div>',
   '          <h3>Commission work from {crafterContext.character.name}</h3>',
-  '          <p>{crafterContext.character.role || crafterContext.character.affiliation || "Town crafter"} • The crafter handles the skill check; you choose the job and materials.</p>',
+  '          <p>{crafterContext.character.role || crafterContext.character.affiliation || "Town crafter"} • Browse the counter, choose the job, provide materials, and the NPC handles the profession check.</p>',
   '        </div>',
-  '        <span className={cls("craft-status-pill", providerValid ? "known" : "danger")}>{providerValid ? "Ready for commission" : "Service unavailable"}</span>'
+  '        <span className={cls("craft-status-pill", providerValid ? "known" : "danger")}>{providerValid ? "Open for commissions" : "Service unavailable"}</span>'
 ].join('\n');
 if (source.includes(providerBefore)) {
   const next = replaceOnce(source, providerBefore, providerAfter, "customer-facing crafter heading");
   changed = changed || next !== source;
   source = next;
 }
+
+const beforeFallbackText = source;
+source = replaceAllSafe(source, "NPC-Assisted Workshop", "Crafter's Counter");
+source = replaceAllSafe(source, "Working with {crafterContext.character.name}", "Commission work from {crafterContext.character.name}");
+source = replaceAllSafe(source, "Profession ready", "Open for commissions");
+source = replaceAllSafe(source, "Configuration required", "Service unavailable");
+source = replaceAllSafe(source, "This NPC does not offer {recipe.discipline}.", "This crafter does not currently offer {recipe.discipline} commissions.");
+if (source !== beforeFallbackText) changed = true;
 
 const unavailableBefore = '      {!providerOffersRequestedProfession ? <div className="craft-plan-alert danger">This NPC does not offer {recipe.discipline}.</div> : null}';
 const unavailableAfter = '      {!providerOffersRequestedProfession ? <div className="craft-plan-alert danger">This crafter does not currently offer {recipe.discipline} commissions.</div> : null}';
@@ -97,7 +109,7 @@ if (source.includes(crafterContextBlock)) {
 }
 
 const recipeTableBefore = '<strong>Recipes Spreadsheet</strong><span className="craft-badge">{filteredRecipes.length} shown</span></div><RecipeTable recipes={filteredRecipes} selected={selected} onSelect={setSelected} />';
-const recipeTableAfter = '<strong>Recipes Spreadsheet</strong><span className="craft-badge">{crafterVisibleRecipes.length} shown</span></div><RecipeTable recipes={crafterVisibleRecipes} selected={selected} onSelect={setSelected} />';
+const recipeTableAfter = '<strong>Crafter\'s Ledger</strong><span className="craft-badge">{crafterVisibleRecipes.length} offered</span></div><RecipeTable recipes={crafterVisibleRecipes} selected={selected} onSelect={setSelected} />';
 if (source.includes(recipeTableBefore)) {
   const next = replaceOnce(source, recipeTableBefore, recipeTableAfter, "NPC scoped recipe table");
   changed = changed || next !== source;
@@ -109,6 +121,14 @@ if (changed) {
   console.log("Applied customer-facing crafter shop presentation and recipe scope patch.");
 } else {
   console.log("Crafter shop presentation already current or awaiting profession generation.");
+}
+
+const globalsPath = path.join(process.cwd(), "styles", "globals.scss");
+let globals = fs.readFileSync(globalsPath, "utf8");
+const styleMarker = "/* ===== NPC crafter counter shop skin v2 ===== */";
+if (!globals.includes(styleMarker)) {
+  globals += `\n\n${styleMarker}\n.craft-provider-card {\n  position: relative;\n  overflow: hidden;\n  border-color: rgba(226, 176, 92, .72) !important;\n  background:\n    radial-gradient(circle at 12% 12%, rgba(246, 204, 119, .18), transparent 32%),\n    linear-gradient(135deg, rgba(75, 48, 31, .94), rgba(28, 23, 38, .96) 48%, rgba(18, 22, 33, .94)) !important;\n  box-shadow: inset 0 0 0 1px rgba(255, 236, 190, .08), 0 18px 42px rgba(0,0,0,.36);\n}\n.craft-provider-card::before {\n  content: \"\";\n  position: absolute;\n  inset: 0;\n  pointer-events: none;\n  background:\n    linear-gradient(90deg, rgba(255,255,255,.04), transparent 28%),\n    repeating-linear-gradient(90deg, rgba(255,255,255,.025) 0 1px, transparent 1px 90px);\n}\n.craft-provider-card > * { position: relative; z-index: 1; }\n.craft-provider-head h3 { color: #fff6db; font-size: clamp(1.25rem, 1vw + 1rem, 1.8rem); }\n.craft-provider-head p { color: #efe2c5; max-width: 760px; }\n.craft-provider-grid > div {\n  border-color: rgba(244, 202, 128, .22) !important;\n  background: linear-gradient(180deg, rgba(20, 16, 24, .62), rgba(8, 8, 12, .72)) !important;\n}\n.craft-provider-layout .craft-step-card {\n  border-color: rgba(226, 176, 92, .52);\n  background: linear-gradient(135deg, rgba(98, 61, 33, .86), rgba(43, 32, 47, .92));\n}\n.craft-provider-layout .craft-step-card-active {\n  background: linear-gradient(135deg, rgba(161, 98, 42, .96), rgba(72, 50, 56, .96));\n}\n.craft-provider-layout .craft-workflow-step-title::before { content: \"Order: \"; color: rgba(255, 230, 160, .65); }\n`;
+  fs.writeFileSync(globalsPath, globals, "utf8");
 }
 
 for (const token of ["activeCrafterContext", "crafterQueryError"]) {

--- a/sql/20260619_01_shop_catalog_enhancement_pass.sql
+++ b/sql/20260619_01_shop_catalog_enhancement_pass.sql
@@ -1,0 +1,17 @@
+-- Shop catalog enhancement pass.
+-- Documents the live data pass that made merchant/crafter shops more complete.
+-- Idempotent intent:
+--   1. Mark Bomb and Oil catalog/stock rows as enhanced merchant-crafted stock.
+--   2. Preserve save/range metadata while adding hidden ingredient boost profiles.
+--   3. Seed a small number of Recipe items into each live merchant stock list.
+--
+-- Live results from the first application:
+--   items_catalog Bomb/Oil rows enhanced: 46
+--   existing character_stock Bomb/Oil rows refreshed from catalog: 5
+--   Recipe stock rows inserted across current merchants: 12
+--
+-- Notes:
+-- - Ingredient provenance/boost profile is stored in payload metadata, not as player-facing ingredient names.
+-- - Buying a Recipe item currently buys an inventory item containing recipe_unlock metadata.
+--   A later pass should convert recipe-item purchase into player_recipes unlocks.
+-- - No NPCs, world-map rows, route rows, movement rows, or Mog records are altered by this pass.

--- a/utils/merchantTheme.js
+++ b/utils/merchantTheme.js
@@ -7,16 +7,16 @@ function normalizeTheme(raw) {
   const s = String(raw || "").toLowerCase();
   if (THEMES.includes(s)) return s;
 
-  // fuzzy matches (name/icon)
-  if (/(smith|anvil|forge|hammer)/.test(s)) return "smith";
-  if (/(weapon|blade|sword)/.test(s)) return "weapons";
-  if (/(potion|alch)/.test(s)) return "alchemy";
-  if (/(leaf|herb|plant)/.test(s)) return "herbalist";
-  if (/(camel|caravan|trader)/.test(s)) return "caravan";
-  if (/(horse|stable|courier)/.test(s)) return "stable";
-  if (/(cloak|cloth|tailor)/.test(s)) return "clothier";
-  if (/(gem|jewel)/.test(s)) return "jeweler";
-  if (/(book|scribe|tome|arcane|wizard|mage)/.test(s)) return "arcanist";
+  // fuzzy matches (name/icon/role/tags/storefront)
+  if (/(smith|blacksmith|anvil|forge|hammer|armorer|armourer)/.test(s)) return "smith";
+  if (/(weapon|blade|sword|bowyer|fletcher|arms)/.test(s)) return "weapons";
+  if (/(potion|alch|apothecary|bomb|oil|poison|elixir)/.test(s)) return "alchemy";
+  if (/(leaf|herb|plant|root|oakshade|botanist|gardener)/.test(s)) return "herbalist";
+  if (/(camel|caravan|trader|trade|wagon|peddler|market)/.test(s)) return "caravan";
+  if (/(horse|stable|courier|mount|saddle)/.test(s)) return "stable";
+  if (/(cloak|cloth|tailor|seamstress|weaver|garb|robe)/.test(s)) return "clothier";
+  if (/(gem|jewel|ring|amulet|relic)/.test(s)) return "jeweler";
+  if (/(book|scribe|tome|arcane|wizard|mage|archivist|archive|map|scroll|lore|ritual|curio)/.test(s)) return "arcanist";
   return "general";
 }
 
@@ -29,20 +29,31 @@ export function backgroundForTheme(theme) {
     fletcher: "/merchant-backgrounds/fletcher.jpg",
     alchemist: "/merchant-backgrounds/alchemist.jpg",
     apothecary: "/merchant-backgrounds/alchemist.jpg",
+    herbalist: "/merchant-backgrounds/alchemist.jpg",
     arcane: "/merchant-backgrounds/arcane.jpg",
+    arcanist: "/merchant-backgrounds/arcane.jpg",
     occult: "/merchant-backgrounds/arcane.jpg",
     dwarven: "/merchant-backgrounds/dwarven.jpg",
     drow: "/merchant-backgrounds/drow.jpg",
     kaorti: "/merchant-backgrounds/kaorti.jpg",
   };
-  return map[t] || "/parchment.jpg"; // fallback matches your current default
+  return map[t] || "/parchment.jpg";
 }
 
 export function themeFromMerchant(m = {}) {
-  // Treat merchants.icon as the explicit theme if it matches; otherwise infer from name/icon.
-  const explicit = normalizeTheme(m.icon);
+  // Explicit icon/theme wins first; then inspect the full storefront identity.
+  const explicit = normalizeTheme(m.icon || m.theme || m.merchant_theme);
   if (explicit !== "general") return explicit;
-  return normalizeTheme((m.name || m.icon || ""));
+  const tags = Array.isArray(m.tags) ? m.tags.join(" ") : String(m.tags || "");
+  const identity = [
+    m.name,
+    m.role,
+    m.affiliation,
+    m.storefront_title,
+    m.storefront_tagline,
+    tags,
+  ].filter(Boolean).join(" ");
+  return normalizeTheme(identity);
 }
 
 export function emojiForTheme(theme) {


### PR DESCRIPTION
## Summary
- Merchant theme detection now uses role, tags, affiliation, storefront title, and storefront tagline instead of only name/icon.
- NPC-assisted crafter view gets stronger shop/counter-facing copy and skin while preserving the existing workflow mechanics.
- Documents the live shop catalog enhancement pass for oils, bombs, and recipe stock.

## Live DB
Already applied to live Supabase:
- Enhanced 46 Bomb/Oil catalog rows with merchant-crafted ingredient boost metadata.
- Refreshed 5 existing Bomb/Oil stock rows from the enriched catalog.
- Inserted 12 recipe stock rows across live merchants so formulas/patterns appear here and there.
- Verified Bomb of Fear still has Wisdom DC 14 and 10-foot radius cloud metadata, plus a hidden duration boost profile.

## Safety
- No NPC deletion.
- Mog untouched.
- No world-map files touched.
- No movement/route/sprite state changed.
- Vercel passed on branch commit `e87f8d4`.