### PR TITLE
Document recipe unlock backend and themed merchant reroll

### DIFF
--- a/sql/20260619_02_recipe_purchase_unlocks_and_reroll.sql
+++ b/sql/20260619_02_recipe_purchase_unlocks_and_reroll.sql
@@ -1,0 +1,19 @@
+-- Recipe purchase unlocks + improved themed merchant reroll.
+-- Applied live before committing this documentation file.
+--
+-- Live backend changes:
+-- - public.buy_from_merchant now treats Recipe stock as learnable formulas/patterns.
+-- - Buying a Recipe row inserts public.player_recipes(player_id, recipe_id).
+-- - Recipe purchases no longer add an inventory clutter row when valid recipe_unlock metadata exists.
+-- - public.reroll_merchant_inventory_v2 now builds a themed shelf mix from items_catalog:
+--   recipes, relevant consumables, relevant materials, then themed catalog fill.
+--
+-- Verification:
+-- - Reroll was tested inside a transaction and rolled back.
+-- - Test alchemy reroll produced 16 rows with recipes, consumables, and materials represented.
+--
+-- Safety:
+-- - No NPC deletion.
+-- - Mog untouched.
+-- - No world-map files touched.
+-- - No movement, route, or sprite rows changed.


### PR DESCRIPTION
## Summary
- Documents the live backend pass for Recipe purchases and themed merchant rerolls.
- Recipe stock now unlocks `player_recipes` through `buy_from_merchant` instead of creating clutter inventory rows.
- Merchant reroll now uses a more varied shelf mix: recipes, relevant consumables, relevant materials, then themed catalog fill.

## Live DB
Already applied to live Supabase:
- Replaced `public.buy_from_merchant(p_merchant_id uuid, p_stock_uuid uuid, p_qty integer)`.
- Replaced `public.reroll_merchant_inventory_v2(p_merchant_id uuid, p_theme text, p_count integer)`.
- Verified reroll in a rolled-back transaction: alchemy reroll generated 16 rows with 3 recipes, 6 consumables, and 7 materials.

## Safety
- No NPC deletion.
- Mog untouched.
- No world-map files touched.
- No movement/route/sprite state changed.
- Vercel passed on branch commit `ef3e505`.