### PR TITLE
Run crafter shop presentation patch during builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "predev": "node scripts/generate_npc_portrait_pack.mjs && node scripts/patch_smithing_base_dice.mjs && node scripts/patch_town_merchant_storefront.mjs && node scripts/patch_merchant_market_ui.mjs && node scripts/patch_merchant_market_polish.mjs && node scripts/patch_itemcard_alchemy_details.mjs && node scripts/patch_npc_forge_creation_details.mjs && node scripts/patch_npc_portrait_foundation_v2.mjs",
+    "predev": "node scripts/generate_npc_portrait_pack.mjs && node scripts/patch_smithing_base_dice.mjs && node scripts/patch_town_merchant_storefront.mjs && node scripts/patch_merchant_market_ui.mjs && node scripts/patch_merchant_market_polish.mjs && node scripts/patch_itemcard_alchemy_details.mjs && node scripts/patch_npc_forge_creation_details.mjs && node scripts/patch_crafter_shop_presentation.mjs && node scripts/patch_npc_portrait_foundation_v2.mjs",
     "dev": "next dev",
-    "prebuild": "node scripts/generate_npc_portrait_pack.mjs && node scripts/patch_smithing_base_dice.mjs && node scripts/patch_town_merchant_storefront.mjs && node scripts/patch_merchant_market_ui.mjs && node scripts/patch_merchant_market_polish.mjs && node scripts/patch_itemcard_alchemy_details.mjs && node scripts/patch_npc_forge_creation_details.mjs && node scripts/patch_npc_portrait_foundation_v2.mjs",
+    "prebuild": "node scripts/generate_npc_portrait_pack.mjs && node scripts/patch_smithing_base_dice.mjs && node scripts/patch_town_merchant_storefront.mjs && node scripts/patch_merchant_market_ui.mjs && node scripts/patch_merchant_market_polish.mjs && node scripts/patch_itemcard_alchemy_details.mjs && node scripts/patch_npc_forge_creation_details.mjs && node scripts/patch_crafter_shop_presentation.mjs && node scripts/patch_npc_portrait_foundation_v2.mjs",
     "build": "next build",
     "start": "next start",
     "seed:items": "node scripts/seed_items_catalog.mjs"


### PR DESCRIPTION
## Summary
- Wires the existing `scripts/patch_crafter_shop_presentation.mjs` into both `predev` and `prebuild`.
- This allows the existing crafter-counter presentation work to run with the rest of the generated UI patches.

## Why
The script already exists in the repo and contains the friendlier NPC-assisted workshop presentation work: `Crafter's Counter` copy, scoped NPC crafter recipe ledger, provider card skinning, and safer delayed crafter load error messaging. It was not included in the build chain, so it would not apply during normal local dev or deployment builds.

## Guardrails
- No world-map movement or route logic touched.
- No Supabase schema changes.
- Only `package.json` build-chain wiring changed.

## Live DB note
I also synchronized existing live character sheet JSON portrait objects from the already-backfilled character portrait paths, so row fields and sheet JSON now agree.